### PR TITLE
Fix CSS nesting serializer bugs with traditional @media blocks

### DIFF
--- a/ext/cataract/cataract.h
+++ b/ext/cataract/cataract.h
@@ -120,6 +120,10 @@ static inline VALUE strip_string(const char *str, long len) {
   #define MAX_PARSE_DEPTH 10  // Max recursion depth for nested @media/@supports blocks and CSS nesting
 #endif
 
+// Max buffer size for indent strings in serialization
+// (MAX_PARSE_DEPTH + 1) * 2 spaces + null terminator, rounded up for safety
+#define MAX_INDENT_BUFFER ((MAX_PARSE_DEPTH + 2) * 2 + 1)
+
 #ifndef MAX_PROPERTY_NAME_LENGTH
   #define MAX_PROPERTY_NAME_LENGTH 256  // Max length of CSS property name
 #endif

--- a/lib/cataract/pure/serializer.rb
+++ b/lib/cataract/pure/serializer.rb
@@ -355,6 +355,9 @@ module Cataract
           current_media = nil
         end
 
+        # Add blank line before base rule if we just closed a media block (ends with "}\n")
+        result << "\n" if result.length > 1 && result.getbyte(-1) == BYTE_NEWLINE && result.getbyte(-2) == BYTE_RBRACE
+
         serialize_rule_with_nesting_formatted(result, rule, rule_children, rule_to_media, '')
       else
         if current_media.nil? || current_media != rule_media

--- a/test/serialization/test_stylesheet_serialization.rb
+++ b/test/serialization/test_stylesheet_serialization.rb
@@ -703,4 +703,61 @@ class TestStylesheetSerialization < Minitest::Test
 
     assert_equal expected, sheet.to_formatted_s
   end
+
+  # Test mixing traditional @media with CSS nesting
+  def test_to_s_traditional_media_followed_by_nested_parent
+    css = <<~CSS
+      @media screen {
+        .screen { color: blue; }
+      }
+      .parent {
+        .child { color: red; }
+      }
+    CSS
+
+    sheet = Cataract::Stylesheet.parse(css)
+    output = sheet.to_s
+
+    # Should serialize with @media block, then nested structure
+    expected = <<~CSS
+      @media screen {
+      .screen { color: blue; }
+      }
+      .parent { .child { color: red; } }
+    CSS
+
+    assert_equal expected, output
+  end
+
+  # Test mixing traditional @media with CSS nesting (formatted)
+  def test_to_formatted_s_traditional_media_followed_by_nested_parent
+    css = <<~CSS
+      @media screen {
+        .screen { color: blue; }
+      }
+      .parent {
+        .child { color: red; }
+      }
+    CSS
+
+    sheet = Cataract::Stylesheet.parse(css)
+    output = sheet.to_formatted_s
+
+    # Should serialize with proper indentation
+    expected = <<~CSS
+      @media screen {
+        .screen {
+          color: blue;
+        }
+      }
+
+      .parent {
+        .child {
+          color: red;
+        }
+      }
+    CSS
+
+    assert_equal expected, output
+  end
 end


### PR DESCRIPTION
Fixed multiple serialization bugs in the C extension when mixing traditional @media blocks with CSS nesting syntax. The nesting-enabled serialization path was missing media block state tracking and proper indentation handling.


1. Missing @media block tracking: Nesting-enabled serializers (stylesheet_to_s_new and stylesheet_to_formatted_s_new) didn't track media block state, causing incorrect output when traditional @media blocks were followed by nested selectors. The @media wrapper was omitted entirely.
2. Incorrect indentation for nested content: Rules inside @media blocks used hardcoded 2-space indentation instead of calculating indent based on nesting
level. This caused declarations inside media blocks to be under-indented.
3. Missing closing brace indentation: Closing braces weren't indented to match their opening selector level.
4. Missing blank lines in formatted output: No blank line was inserted after closing a media block before starting a base rule.

## Before/After Examples

### Input CSS
```css
@media screen {
  .screen { color: blue; }
}
.parent {
  .child { color: red; }
}
```

### Compact Mode (`to_s`)

#### Before (broken)
```css
.screen { color: blue; }
.parent { .child { color: red; } }
```
- `@media` wrapper completely missing
- Rules from inside media block appear at top level

#### After (fixed)
```css
@media screen {
.screen { color: blue; }
}
.parent { .child { color: red; } }
```
- `@media` block properly wrapped
- Nesting preserved

---

### Formatted Mode (`to_formatted_s`)

#### Before (broken)
```css
@media screen {
  .screen {
  color: blue;
}
}
.parent {
  .child {
    color: red;
  }
}
```
- Missing 2 spaces of indentation for `.screen` selector
- Only 2 spaces for `color: blue;` instead of 4
- Closing brace `}` not indented properly
- No blank line between `@media` block and `.parent`

#### After (fixed)
```css
@media screen {
  .screen {
    color: blue;
  }
}

.parent {
  .child {
    color: red;
  }
}
```
- Proper 2-space indent for `.screen` selector
- Proper 4-space indent for declarations inside media
- Closing braces aligned correctly
- Blank line separating media block from base rules
