### PR TITLE
Selector lists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -171,5 +171,7 @@ Cataract/BanAssertIncludes:
   Include:
     - 'test/**/*'
   Exclude:
+    - 'test/color/**/*.rb'
     - 'test/test_benchmark_doc_generator.rb'
+    - 'test/test_speedup_calculator.rb'
     - 'test/support/**/*'  # Support files define assert_contains which uses assert_includes internally

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -20,16 +20,17 @@ Time to parse CSS into internal data structures
 
 | Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
 |-----------|--------|----------------|-------------|----------------------|-------------------|
-| Small CSS (64 lines, 1.0KB) | 62.47K i/s | 3.59K i/s | 15.67K i/s | 4.73K i/s | 6.17K i/s |
-| Medium CSS with @media (139 lines, 1.6KB) | 39.7K i/s | 2.05K i/s | 8.64K i/s | 2.76K i/s | 3.52K i/s |
+| Small CSS (64 lines, 1.0KB) | 35.99K i/s | 3.51K i/s | 14.54K i/s | N/A | N/A |
+| Medium CSS with @media (139 lines, 1.6KB) | 36.65K i/s | 2.14K i/s | 9.56K i/s | N/A | N/A |
+| Selector lists (3500 lines, 62.5KB, 500 lists) | 441.4 i/s | 59.0 i/s | 218.1 i/s | N/A | N/A |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 18.4x faster (avg) |
-| Native vs Pure (YJIT) | 4.2x faster (avg) |
-| YJIT impact on Pure Ruby | 4.31x faster (avg) |
+| Native vs Pure (no YJIT) | 11.77x faster (avg) |
+| Native vs Pure (YJIT) | 3.0x faster (avg) |
+| YJIT impact on Pure Ruby | 4.25x faster (avg) |
 
 ---
 
@@ -39,16 +40,19 @@ Time to convert parsed CSS back to string format
 
 | Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
 |-----------|--------|----------------|-------------|----------------------|-------------------|
-| Full Serialization (Bootstrap CSS - 191KB) | 1.77K i/s | 444.3 i/s | 676.3 i/s | 37.1 i/s | 35.9 i/s |
-| Media Type Filtering (print only) | 282.58K i/s | 114.27K i/s | 155.82K i/s | 2.67K i/s | 4.03K i/s |
+| to_s (Bootstrap - 191KB) | 1.16K i/s | 34.9 i/s | 49.7 i/s | N/A | N/A |
+| to_s (Compact utilities - 2.9KB) | 1.16K i/s | 34.9 i/s | 49.7 i/s | N/A | N/A |
+| to_formatted_s (Nested CSS - 1.3KB) | 158.75K i/s | 63.62K i/s | 114.79K i/s | N/A | N/A |
+| to_s with selector_lists (3.4KB) | 17.95K i/s | 1.43K i/s | 1.99K i/s | N/A | N/A |
+| Media filtering (Bootstrap print only) | 235.05K i/s | 98.95K i/s | 149.3K i/s | N/A | N/A |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 3.23x faster (avg) |
-| Native vs Pure (YJIT) | 1.82x faster (avg) |
-| YJIT impact on Pure Ruby | 1.36x faster (avg) |
+| Native vs Pure (no YJIT) | 10.97x faster (avg) |
+| Native vs Pure (YJIT) | 1.63x faster (avg) |
+| YJIT impact on Pure Ruby | 1.63x faster (avg) |
 
 ---
 
@@ -58,20 +62,20 @@ Time to calculate CSS selector specificity values
 
 | Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
 |-----------|--------|----------------|-------------|----------------------|-------------------|
-| Simple Selectors | 7.35M i/s | 506.04K i/s | 2.59M i/s | 357.72K i/s | 353.42K i/s |
-| Compound Selectors | 6.36M i/s | 184.96K i/s | 406.99K i/s | 216.59K i/s | 214.86K i/s |
-| Combinators | 5.04M i/s | 146.91K i/s | 252.94K i/s | 185.44K i/s | 183.71K i/s |
-| Pseudo-classes & Pseudo-elements | 5.1M i/s | 116.46K i/s | 197.06K i/s | 113.05K i/s | 113.99K i/s |
-| :not() Pseudo-class (CSS3) | 3.23M i/s | 102.63K i/s | 161.55K i/s | 144.04K i/s | 144.53K i/s |
-| Complex Real-world Selectors | 4.01M i/s | 52.03K i/s | 77.65K i/s | 83.91K i/s | 82.03K i/s |
+| Simple Selectors | 8.42M i/s | 508.29K i/s | 2.6M i/s | 374.96K i/s | 367.05K i/s |
+| Compound Selectors | 6.6M i/s | 186.16K i/s | 400.7K i/s | 224.91K i/s | 217.08K i/s |
+| Combinators | 5.21M i/s | 147.76K i/s | 255.26K i/s | 191.61K i/s | 185.79K i/s |
+| Pseudo-classes & Pseudo-elements | 5.39M i/s | 117.25K i/s | 196.91K i/s | 118.55K i/s | 117.22K i/s |
+| :not() Pseudo-class (CSS3) | 3.48M i/s | 103.11K i/s | 164.66K i/s | 147.38K i/s | 147.53K i/s |
+| Complex Real-world Selectors | 4.05M i/s | 52.17K i/s | 78.28K i/s | 85.57K i/s | 83.39K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 39.27x faster (avg) |
-| Native vs Pure (YJIT) | 8.43x faster (avg) |
-| YJIT impact on Pure Ruby | 3.32x faster (avg) |
+| Native vs Pure (no YJIT) | 40.75x faster (avg) |
+| Native vs Pure (YJIT) | 8.97x faster (avg) |
+| YJIT impact on Pure Ruby | 3.31x faster (avg) |
 
 ---
 
@@ -81,20 +85,20 @@ Time to flatten multiple CSS rule sets with same selector
 
 | Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
 |-----------|--------|----------------|-------------|----------------------|-------------------|
-| No shorthand properties (large) | 21.34K i/s | 3.11K i/s | 5.23K i/s | 1.58K i/s | 2.3K i/s |
-| Simple properties | 158.81K i/s | 75.72K i/s | 102.44K i/s | 28.29K i/s | 40.72K i/s |
-| Cascade with specificity | 204.11K i/s | 77.93K i/s | 108.77K i/s | 31.92K i/s | 46.39K i/s |
-| Important declarations | 203.43K i/s | 77.88K i/s | 109.38K i/s | 31.25K i/s | 45.25K i/s |
-| Shorthand expansion | 21.34K i/s | 3.11K i/s | 5.23K i/s | 1.58K i/s | 2.3K i/s |
-| Complex merging | 30.94K i/s | 16.09K i/s | 21.57K i/s | 11.6K i/s | 16.63K i/s |
+| No shorthand properties (large) | 20.74K i/s | 3.15K i/s | 5.73K i/s | 1.56K i/s | 2.31K i/s |
+| Simple properties | 155.01K i/s | 73.1K i/s | 99.95K i/s | 28.51K i/s | 41.51K i/s |
+| Cascade with specificity | 194.63K i/s | 74.22K i/s | 104.8K i/s | 32.03K i/s | 47.33K i/s |
+| Important declarations | 195.45K i/s | 72.82K i/s | 105.65K i/s | 31.66K i/s | 45.46K i/s |
+| Shorthand expansion | 20.74K i/s | 3.15K i/s | 5.73K i/s | 1.56K i/s | 2.31K i/s |
+| Complex flattening | 31.19K i/s | 15.81K i/s | 21.52K i/s | 11.57K i/s | 16.02K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 3.03x faster (avg) |
-| Native vs Pure (YJIT) | 1.72x faster (avg) |
-| YJIT impact on Pure Ruby | 1.38x faster (avg) |
+| Native vs Pure (no YJIT) | 3.01x faster (avg) |
+| Native vs Pure (YJIT) | 1.7x faster (avg) |
+| YJIT impact on Pure Ruby | 1.41x faster (avg) |
 
 ---
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -4,7 +4,7 @@
 
 # Performance Benchmarks
 
-Performance comparison between Cataract's C extension and pure Ruby implementations, with css_parser as a reference.
+Performance comparison between Cataract's C extension and pure Ruby implementations.
 
 ## Test Environment
 
@@ -18,19 +18,19 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 
 Time to parse CSS into internal data structures
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
-|-----------|--------|----------------|-------------|----------------------|-------------------|
-| Small CSS (64 lines, 1.0KB) | 35.99K i/s | 3.51K i/s | 14.54K i/s | N/A | N/A |
-| Medium CSS with @media (139 lines, 1.6KB) | 36.65K i/s | 2.14K i/s | 9.56K i/s | N/A | N/A |
-| Selector lists (3500 lines, 62.5KB, 500 lists) | 441.4 i/s | 59.0 i/s | 218.1 i/s | N/A | N/A |
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
+|-----------|--------|----------------|-------------|
+| Small CSS (64 lines, 1.0KB) | 35.99K i/s | 3.51K i/s | 14.54K i/s |
+| Medium CSS with @media (139 lines, 1.6KB) | 36.65K i/s | 2.14K i/s | 9.56K i/s |
+| Selector lists (3500 lines, 62.5KB, 500 lists) | 441.4 i/s | 59.0 i/s | 218.1 i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
 | Native vs Pure (no YJIT) | 11.77x faster (avg) |
-| Native vs Pure (YJIT) | 3.0x faster (avg) |
-| YJIT impact on Pure Ruby | 4.25x faster (avg) |
+| Native vs Pure (YJIT) | 2.77x faster (avg) |
+| YJIT impact on Pure Ruby | 4.18x faster (avg) |
 
 ---
 
@@ -38,21 +38,21 @@ Time to parse CSS into internal data structures
 
 Time to convert parsed CSS back to string format
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
-|-----------|--------|----------------|-------------|----------------------|-------------------|
-| to_s (Bootstrap - 191KB) | 1.16K i/s | 34.9 i/s | 49.7 i/s | N/A | N/A |
-| to_s (Compact utilities - 2.9KB) | 1.16K i/s | 34.9 i/s | 49.7 i/s | N/A | N/A |
-| to_formatted_s (Nested CSS - 1.3KB) | 158.75K i/s | 63.62K i/s | 114.79K i/s | N/A | N/A |
-| to_s with selector_lists (3.4KB) | 17.95K i/s | 1.43K i/s | 1.99K i/s | N/A | N/A |
-| Media filtering (Bootstrap print only) | 235.05K i/s | 98.95K i/s | 149.3K i/s | N/A | N/A |
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
+|-----------|--------|----------------|-------------|
+| to_s (Bootstrap - 191KB) | 1.16K i/s | 34.9 i/s | 49.7 i/s |
+| to_s (Compact utilities - 2.9KB) | 1.16K i/s | 34.9 i/s | 49.7 i/s |
+| to_formatted_s (Nested CSS - 1.3KB) | 158.75K i/s | 63.62K i/s | 114.79K i/s |
+| to_s with selector_lists (3.4KB) | 17.95K i/s | 1.43K i/s | 1.99K i/s |
+| Media filtering (Bootstrap print only) | 235.05K i/s | 98.95K i/s | 149.3K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
 | Native vs Pure (no YJIT) | 10.97x faster (avg) |
-| Native vs Pure (YJIT) | 1.63x faster (avg) |
-| YJIT impact on Pure Ruby | 1.63x faster (avg) |
+| Native vs Pure (YJIT) | 7.56x faster (avg) |
+| YJIT impact on Pure Ruby | 1.57x faster (avg) |
 
 ---
 
@@ -60,22 +60,22 @@ Time to convert parsed CSS back to string format
 
 Time to calculate CSS selector specificity values
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
-|-----------|--------|----------------|-------------|----------------------|-------------------|
-| Simple Selectors | 8.42M i/s | 508.29K i/s | 2.6M i/s | 374.96K i/s | 367.05K i/s |
-| Compound Selectors | 6.6M i/s | 186.16K i/s | 400.7K i/s | 224.91K i/s | 217.08K i/s |
-| Combinators | 5.21M i/s | 147.76K i/s | 255.26K i/s | 191.61K i/s | 185.79K i/s |
-| Pseudo-classes & Pseudo-elements | 5.39M i/s | 117.25K i/s | 196.91K i/s | 118.55K i/s | 117.22K i/s |
-| :not() Pseudo-class (CSS3) | 3.48M i/s | 103.11K i/s | 164.66K i/s | 147.38K i/s | 147.53K i/s |
-| Complex Real-world Selectors | 4.05M i/s | 52.17K i/s | 78.28K i/s | 85.57K i/s | 83.39K i/s |
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
+|-----------|--------|----------------|-------------|
+| Simple Selectors | 8.42M i/s | 508.29K i/s | 2.6M i/s |
+| Compound Selectors | 6.6M i/s | 186.16K i/s | 400.7K i/s |
+| Combinators | 5.21M i/s | 147.76K i/s | 255.26K i/s |
+| Pseudo-classes & Pseudo-elements | 5.39M i/s | 117.25K i/s | 196.91K i/s |
+| :not() Pseudo-class (CSS3) | 3.48M i/s | 103.11K i/s | 164.66K i/s |
+| Complex Real-world Selectors | 4.05M i/s | 52.17K i/s | 78.28K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
 | Native vs Pure (no YJIT) | 40.75x faster (avg) |
-| Native vs Pure (YJIT) | 8.97x faster (avg) |
-| YJIT impact on Pure Ruby | 3.31x faster (avg) |
+| Native vs Pure (YJIT) | 23.38x faster (avg) |
+| YJIT impact on Pure Ruby | 2.29x faster (avg) |
 
 ---
 
@@ -83,22 +83,22 @@ Time to calculate CSS selector specificity values
 
 Time to flatten multiple CSS rule sets with same selector
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
-|-----------|--------|----------------|-------------|----------------------|-------------------|
-| No shorthand properties (large) | 20.74K i/s | 3.15K i/s | 5.73K i/s | 1.56K i/s | 2.31K i/s |
-| Simple properties | 155.01K i/s | 73.1K i/s | 99.95K i/s | 28.51K i/s | 41.51K i/s |
-| Cascade with specificity | 194.63K i/s | 74.22K i/s | 104.8K i/s | 32.03K i/s | 47.33K i/s |
-| Important declarations | 195.45K i/s | 72.82K i/s | 105.65K i/s | 31.66K i/s | 45.46K i/s |
-| Shorthand expansion | 20.74K i/s | 3.15K i/s | 5.73K i/s | 1.56K i/s | 2.31K i/s |
-| Complex flattening | 31.19K i/s | 15.81K i/s | 21.52K i/s | 11.57K i/s | 16.02K i/s |
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
+|-----------|--------|----------------|-------------|
+| No shorthand properties (large) | 20.74K i/s | 3.15K i/s | 5.73K i/s |
+| Simple properties | 155.01K i/s | 73.1K i/s | 99.95K i/s |
+| Cascade with specificity | 194.63K i/s | 74.22K i/s | 104.8K i/s |
+| Important declarations | 195.45K i/s | 72.82K i/s | 105.65K i/s |
+| Shorthand expansion | 20.74K i/s | 3.15K i/s | 5.73K i/s |
+| Complex flattening | 31.19K i/s | 15.81K i/s | 21.52K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
 | Native vs Pure (no YJIT) | 3.01x faster (avg) |
-| Native vs Pure (YJIT) | 1.7x faster (avg) |
-| YJIT impact on Pure Ruby | 1.41x faster (avg) |
+| Native vs Pure (YJIT) | 1.97x faster (avg) |
+| YJIT impact on Pure Ruby | 1.47x faster (avg) |
 
 ---
 
@@ -122,5 +122,4 @@ rake benchmark:generate_docs
 
 - Benchmarks use benchmark-ips with 1-2s warmup and 2-5s measurement periods
 - Measurements show median iterations per second (i/s)
-- css_parser gem is included for reference comparison
 - YJIT is enabled/disabled per subprocess for accurate comparison

--- a/benchmarks/benchmark_flattening.rb
+++ b/benchmarks/benchmark_flattening.rb
@@ -8,7 +8,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'cataract'
 
 # CSS Flattening Benchmark
-# Compares css_parser gem vs Cataract pure Ruby vs Cataract C extension
+# Compares Cataract pure Ruby vs Cataract C extension
 class FlatteningBenchmark < BenchmarkHarness
   def self.benchmark_name
     'flattening'
@@ -29,9 +29,6 @@ class FlatteningBenchmark < BenchmarkHarness
   end
 
   def sanity_checks
-    # Verify css_parser gem is available
-    require 'css_parser'
-
     # Verify cataract works
     css = ".test { color: black; }\n.test { margin: 10px; }"
     cataract_rules = Cataract.parse_css(css)
@@ -53,7 +50,6 @@ class FlatteningBenchmark < BenchmarkHarness
 
     # Define implementations to test
     implementations = [
-      { name: 'css_parser gem', base_impl: :css_parser, env: { 'FLATTENING_CSS_PARSER' => '1' } },
       { name: 'Cataract pure Ruby', base_impl: :pure, env: { 'CATARACT_PURE' => '1' } },
       { name: 'Cataract C extension', base_impl: :native, env: { 'CATARACT_PURE' => nil } }
     ]

--- a/benchmarks/benchmark_flattening_workers.rb
+++ b/benchmarks/benchmark_flattening_workers.rb
@@ -7,33 +7,6 @@ require_relative 'worker_helpers'
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-# Worker benchmark: css_parser gem
-class MergingCssParserBenchmark < BenchmarkHarness
-  include FlatteningTests
-  include WorkerHelpers
-
-  def self.benchmark_name
-    'flattening_css_parser'
-  end
-
-  def self.description
-    'CSS flattening with css_parser gem'
-  end
-
-  def self.metadata
-    FlatteningTests.metadata
-  end
-
-  def self.speedup_config
-    FlatteningTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type_with_yjit(:css_parser, FlatteningTests)
-  end
-end
-
 # Worker benchmark: Cataract pure Ruby
 class MergingCataractPureBenchmark < BenchmarkHarness
   include FlatteningTests
@@ -90,16 +63,11 @@ end
 
 # CLI entry point - run the appropriate worker
 if __FILE__ == $PROGRAM_NAME
-  if ENV['FLATTENING_CSS_PARSER']
-    require 'css_parser'
-    MergingCssParserBenchmark.run(skip_finalize: true)
-  else
-    require 'cataract'
+  require 'cataract'
 
-    if Cataract::IMPLEMENTATION == :ruby
-      MergingCataractPureBenchmark.run(skip_finalize: true)
-    else
-      MergingCataractNativeBenchmark.run(skip_finalize: true)
-    end
+  if Cataract::IMPLEMENTATION == :ruby
+    MergingCataractPureBenchmark.run(skip_finalize: true)
+  else
+    MergingCataractNativeBenchmark.run(skip_finalize: true)
   end
 end

--- a/benchmarks/benchmark_harness.rb
+++ b/benchmarks/benchmark_harness.rb
@@ -93,6 +93,13 @@ class BenchmarkHarness
       instance = new
       setup
       instance.sanity_checks if instance.respond_to?(:sanity_checks, true)
+
+      # Warm up the VM before benchmarking for stable, reproducible results
+      # This runs a major GC, compacts the heap, promotes objects to old gen,
+      # and prepares YJIT/internal state for optimal performance
+      # https://docs.ruby-lang.org/en/master/Process.html#method-c-warmup
+      Process.warmup
+
       instance.call
       finalize(instance) unless skip_finalize
     rescue StandardError => e

--- a/benchmarks/benchmark_harness.rb
+++ b/benchmarks/benchmark_harness.rb
@@ -79,11 +79,11 @@ class BenchmarkHarness
     #     test_case_key: Symbol        # Key in test_cases metadata matching test_case_id
     #   }
     def speedup_config
-      # Default: compare css_parser (baseline) vs cataract (comparison)
+      # Default: compare cataract pure without YJIT (baseline) vs cataract native (comparison)
       # Match to test_cases by 'fixture' key
       {
-        baseline_matcher: SpeedupCalculator::Matchers.css_parser,
-        comparison_matcher: SpeedupCalculator::Matchers.cataract,
+        baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
+        comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
         test_case_key: :fixture
       }
     end

--- a/benchmarks/benchmark_parsing_workers.rb
+++ b/benchmarks/benchmark_parsing_workers.rb
@@ -7,33 +7,6 @@ require_relative 'worker_helpers'
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-# Worker benchmark: css_parser gem
-class ParsingCssParserBenchmark < BenchmarkHarness
-  include ParsingTests
-  include WorkerHelpers
-
-  def self.benchmark_name
-    'parsing_css_parser'
-  end
-
-  def self.description
-    'CSS parsing with css_parser gem'
-  end
-
-  def self.metadata
-    ParsingTests.metadata
-  end
-
-  def self.speedup_config
-    ParsingTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type_with_yjit(:css_parser, ParsingTests)
-  end
-end
-
 # Worker benchmark: Cataract pure Ruby
 class ParsingCataractPureBenchmark < BenchmarkHarness
   include ParsingTests
@@ -88,20 +61,14 @@ class ParsingCataractNativeBenchmark < BenchmarkHarness
   end
 end
 
-# CLI entry point - run the appropriate worker based on what's available
+# CLI entry point - run the appropriate worker
 if __FILE__ == $PROGRAM_NAME
-  # Check if we should use css_parser (PARSING_CSS_PARSER env var)
-  if ENV['PARSING_CSS_PARSER']
-    require 'css_parser'
-    ParsingCssParserBenchmark.run(skip_finalize: true)
-  else
-    # Load Cataract (will be pure or native depending on CATARACT_PURE)
-    require 'cataract'
+  # Load Cataract (will be pure or native depending on CATARACT_PURE)
+  require 'cataract'
 
-    if Cataract::IMPLEMENTATION == :ruby
-      ParsingCataractPureBenchmark.run(skip_finalize: true)
-    else
-      ParsingCataractNativeBenchmark.run(skip_finalize: true)
-    end
+  if Cataract::IMPLEMENTATION == :ruby
+    ParsingCataractPureBenchmark.run(skip_finalize: true)
+  else
+    ParsingCataractNativeBenchmark.run(skip_finalize: true)
   end
 end

--- a/benchmarks/benchmark_serialization.rb
+++ b/benchmarks/benchmark_serialization.rb
@@ -8,7 +8,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'cataract'
 
 # CSS Serialization Performance Benchmark
-# Compares css_parser gem vs Cataract pure Ruby vs Cataract C extension
+# Compares Cataract pure Ruby vs Cataract C extension
 class SerializationBenchmark < BenchmarkHarness
   def self.benchmark_name
     'serialization'
@@ -33,9 +33,6 @@ class SerializationBenchmark < BenchmarkHarness
     bootstrap_path = File.expand_path('../test/fixtures/bootstrap.css', __dir__)
     raise "Bootstrap CSS fixture not found at #{bootstrap_path}" unless File.exist?(bootstrap_path)
 
-    # Verify css_parser gem is available
-    require 'css_parser'
-
     # Verify cataract works
     bootstrap_css = File.read(bootstrap_path)
     cataract_sheet = Cataract.parse_css(bootstrap_css)
@@ -57,7 +54,6 @@ class SerializationBenchmark < BenchmarkHarness
 
     # Define implementations to test
     implementations = [
-      { name: 'css_parser gem', base_impl: :css_parser, env: { 'SERIALIZATION_CSS_PARSER' => '1' } },
       { name: 'Cataract pure Ruby', base_impl: :pure, env: { 'CATARACT_PURE' => '1' } },
       { name: 'Cataract C extension', base_impl: :native, env: { 'CATARACT_PURE' => nil } }
     ]
@@ -183,24 +179,11 @@ class SerializationBenchmark < BenchmarkHarness
 
     puts "Input: Bootstrap CSS (#{bootstrap_css.length} bytes)"
 
-    # Parse with both libraries
+    # Parse and serialize
     cataract_sheet = Cataract.parse_css(bootstrap_css)
-    require 'css_parser'
-    css_parser = CssParser::Parser.new
-    css_parser.add_block!(bootstrap_css)
-
-    # Serialize
     cataract_output = cataract_sheet.to_s
-    css_parser_output = css_parser.to_s
 
     puts "Cataract output: #{cataract_output.length} bytes (#{cataract_sheet.size} rules)"
-    puts "css_parser output: #{css_parser_output.length} bytes"
-
-    # Basic sanity check - outputs should be similar in size
-    size_ratio = cataract_output.length.to_f / css_parser_output.length
-    unless size_ratio > 0.8 && size_ratio < 1.2
-      puts "⚠️  Output sizes differ significantly (ratio: #{size_ratio.round(2)})"
-    end
 
     # Check that output can be re-parsed
     begin

--- a/benchmarks/benchmark_serialization_workers.rb
+++ b/benchmarks/benchmark_serialization_workers.rb
@@ -7,33 +7,6 @@ require_relative 'worker_helpers'
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-# Worker benchmark: css_parser gem
-class SerializationCssParserBenchmark < BenchmarkHarness
-  include SerializationTests
-  include WorkerHelpers
-
-  def self.benchmark_name
-    'serialization_css_parser'
-  end
-
-  def self.description
-    'CSS serialization with css_parser gem'
-  end
-
-  def self.metadata
-    SerializationTests.metadata
-  end
-
-  def self.speedup_config
-    SerializationTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type_with_yjit(:css_parser, SerializationTests)
-  end
-end
-
 # Worker benchmark: Cataract pure Ruby
 class SerializationCataractPureBenchmark < BenchmarkHarness
   include SerializationTests
@@ -90,16 +63,11 @@ end
 
 # CLI entry point - run the appropriate worker
 if __FILE__ == $PROGRAM_NAME
-  if ENV['SERIALIZATION_CSS_PARSER']
-    require 'css_parser'
-    SerializationCssParserBenchmark.run(skip_finalize: true)
-  else
-    require 'cataract'
+  require 'cataract'
 
-    if Cataract::IMPLEMENTATION == :ruby
-      SerializationCataractPureBenchmark.run(skip_finalize: true)
-    else
-      SerializationCataractNativeBenchmark.run(skip_finalize: true)
-    end
+  if Cataract::IMPLEMENTATION == :ruby
+    SerializationCataractPureBenchmark.run(skip_finalize: true)
+  else
+    SerializationCataractNativeBenchmark.run(skip_finalize: true)
   end
 end

--- a/benchmarks/benchmark_shorthand_expansion.rb
+++ b/benchmarks/benchmark_shorthand_expansion.rb
@@ -3,16 +3,6 @@
 require 'benchmark/ips'
 require 'cataract'
 
-# Load css_parser for comparison
-begin
-  require 'css_parser'
-  CSS_PARSER_AVAILABLE = true
-rescue LoadError
-  CSS_PARSER_AVAILABLE = false
-  puts 'Warning: css_parser gem not found. Install with: gem install css_parser'
-  puts 'Running Cataract-only benchmarks...'
-end
-
 # Test values
 MARGIN_VALUES = [
   '10px',
@@ -35,61 +25,15 @@ FONT_VALUES = [
 ].freeze
 
 puts "\n=== Shorthand Expansion Benchmark ==="
-puts "Comparing Cataract (C) vs css_parser (Ruby)\n\n"
-
-# Sanity check: verify both implementations produce same results
-if CSS_PARSER_AVAILABLE
-  puts '--- Sanity Check: Comparing Outputs ---'
-
-  # Test margin expansion
-  cataract_result = Cataract._expand_margin('10px 20px 30px 40px')
-  css_parser_rs = CssParser::RuleSet.new(block: 'margin: 10px 20px 30px 40px')
-  css_parser_rs.expand_shorthand!
-  css_parser_result = {}
-  css_parser_rs.each_declaration { |prop, val, _| css_parser_result[prop] = val }
-
-  if cataract_result == css_parser_result
-    puts '✓ Margin expansion: MATCH'
-  else
-    puts '✗ Margin expansion: MISMATCH'
-    puts "  Cataract: #{cataract_result.inspect}"
-    puts "  css_parser: #{css_parser_result.inspect}"
-    exit 1
-  end
-
-  # Test border expansion
-  cataract_result = Cataract._expand_border('1px solid red')
-  css_parser_rs = CssParser::RuleSet.new(block: 'border: 1px solid red')
-  css_parser_rs.expand_shorthand!
-  css_parser_result = {}
-  css_parser_rs.each_declaration { |prop, val, _| css_parser_result[prop] = val }
-
-  if cataract_result == css_parser_result
-    puts '✓ Border expansion: MATCH'
-  else
-    puts '✗ Border expansion: MISMATCH'
-    puts "  Cataract: #{cataract_result.inspect}"
-    puts "  css_parser: #{css_parser_result.inspect}"
-    exit 1
-  end
-
-  puts "All sanity checks passed!\n\n"
-end
+puts "Benchmarking Cataract shorthand expansion\n\n"
 
 # Margin expansion
 puts '--- Margin Expansion (4 values) ---'
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
 
-  x.report('Cataract (C)') do
+  x.report('Cataract') do
     Cataract._expand_margin('10px 20px 30px 40px')
-  end
-
-  if CSS_PARSER_AVAILABLE
-    x.report('css_parser (Ruby)') do
-      rs = CssParser::RuleSet.new(block: 'margin: 10px 20px 30px 40px')
-      rs.expand_shorthand!
-    end
   end
 
   x.compare!
@@ -100,15 +44,8 @@ puts "\n--- Margin with calc() ---"
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
 
-  x.report('Cataract (C)') do
+  x.report('Cataract') do
     Cataract._expand_margin('10px calc(100% - 20px)')
-  end
-
-  if CSS_PARSER_AVAILABLE
-    x.report('css_parser (Ruby)') do
-      rs = CssParser::RuleSet.new(block: 'margin: 10px calc(100% - 20px)')
-      rs.expand_shorthand!
-    end
   end
 
   x.compare!
@@ -119,15 +56,8 @@ puts "\n--- Margin with !important ---"
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
 
-  x.report('Cataract (C)') do
+  x.report('Cataract') do
     Cataract._expand_margin('10px !important')
-  end
-
-  if CSS_PARSER_AVAILABLE
-    x.report('css_parser (Ruby)') do
-      rs = CssParser::RuleSet.new(block: 'margin: 10px !important')
-      rs.expand_shorthand!
-    end
   end
 
   x.compare!
@@ -138,15 +68,8 @@ puts "\n--- Border Expansion ---"
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
 
-  x.report('Cataract (C)') do
+  x.report('Cataract') do
     Cataract._expand_border('1px solid red')
-  end
-
-  if CSS_PARSER_AVAILABLE
-    x.report('css_parser (Ruby)') do
-      rs = CssParser::RuleSet.new(block: 'border: 1px solid red')
-      rs.expand_shorthand!
-    end
   end
 
   x.compare!
@@ -157,15 +80,8 @@ puts "\n--- Font Expansion ---"
 Benchmark.ips do |x|
   x.config(time: 5, warmup: 2)
 
-  x.report('Cataract (C)') do
+  x.report('Cataract') do
     Cataract._expand_font("bold 14px/1.5 'Helvetica Neue', sans-serif")
-  end
-
-  if CSS_PARSER_AVAILABLE
-    x.report('css_parser (Ruby)') do
-      rs = CssParser::RuleSet.new(block: "font: bold 14px/1.5 'Helvetica Neue', sans-serif")
-      rs.expand_shorthand!
-    end
   end
 
   x.compare!
@@ -173,4 +89,3 @@ end
 
 puts "\n=== Summary ==="
 puts 'Cataract uses a C implementation with Ragel state machine for value splitting'
-puts 'css_parser uses pure Ruby with regex-based parsing'

--- a/benchmarks/benchmark_specificity.rb
+++ b/benchmarks/benchmark_specificity.rb
@@ -8,7 +8,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'cataract'
 
 # CSS Specificity Calculation Benchmark
-# Compares css_parser gem vs Cataract pure Ruby vs Cataract C extension
+# Compares Cataract pure Ruby vs Cataract C extension
 class SpecificityBenchmark < BenchmarkHarness
   def self.benchmark_name
     'specificity'
@@ -29,11 +29,7 @@ class SpecificityBenchmark < BenchmarkHarness
   end
 
   def sanity_checks
-    # Verify css_parser gem is available
-    require 'css_parser'
-
     # Verify both libraries work
-    raise 'css_parser sanity check failed' unless CssParser.calculate_specificity('div') == 1
     raise 'Cataract sanity check failed' unless Cataract.calculate_specificity('div') == 1
   end
 
@@ -51,7 +47,6 @@ class SpecificityBenchmark < BenchmarkHarness
 
     # Define implementations to test
     implementations = [
-      { name: 'css_parser gem', base_impl: :css_parser, env: { 'SPECIFICITY_CSS_PARSER' => '1' } },
       { name: 'Cataract pure Ruby', base_impl: :pure, env: { 'CATARACT_PURE' => '1' } },
       { name: 'Cataract C extension', base_impl: :native, env: { 'CATARACT_PURE' => nil } }
     ]

--- a/benchmarks/benchmark_specificity_workers.rb
+++ b/benchmarks/benchmark_specificity_workers.rb
@@ -7,33 +7,6 @@ require_relative 'worker_helpers'
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-# Worker benchmark: css_parser gem
-class SpecificityCssParserBenchmark < BenchmarkHarness
-  include SpecificityTests
-  include WorkerHelpers
-
-  def self.benchmark_name
-    'specificity_css_parser'
-  end
-
-  def self.description
-    'CSS specificity calculation with css_parser gem'
-  end
-
-  def self.metadata
-    SpecificityTests.metadata
-  end
-
-  def self.speedup_config
-    SpecificityTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type_with_yjit(:css_parser, SpecificityTests)
-  end
-end
-
 # Worker benchmark: Cataract pure Ruby
 class SpecificityCataractPureBenchmark < BenchmarkHarness
   include SpecificityTests
@@ -90,16 +63,11 @@ end
 
 # CLI entry point - run the appropriate worker
 if __FILE__ == $PROGRAM_NAME
-  if ENV['SPECIFICITY_CSS_PARSER']
-    require 'css_parser'
-    SpecificityCssParserBenchmark.run(skip_finalize: true)
-  else
-    require 'cataract'
+  require 'cataract'
 
-    if Cataract::IMPLEMENTATION == :ruby
-      SpecificityCataractPureBenchmark.run(skip_finalize: true)
-    else
-      SpecificityCataractNativeBenchmark.run(skip_finalize: true)
-    end
+  if Cataract::IMPLEMENTATION == :ruby
+    SpecificityCataractPureBenchmark.run(skip_finalize: true)
+  else
+    SpecificityCataractNativeBenchmark.run(skip_finalize: true)
   end
 end

--- a/benchmarks/fixtures/selector_lists.css
+++ b/benchmarks/fixtures/selector_lists.css
@@ -1,0 +1,3500 @@
+.class-0-1, .class-0-2, .class-0-3 {
+  color: #000000;
+  font-size: 12px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.class-1-1, .class-1-2, .class-1-3, .class-1-4 {
+  color: #000101;
+  font-size: 13px;
+  margin: 1px;
+  padding: 1px;
+}
+
+.class-2-1, .class-2-2, .class-2-3, .class-2-4, .class-2-5 {
+  color: #000202;
+  font-size: 14px;
+  margin: 2px;
+  padding: 2px;
+}
+
+.class-3-1, .class-3-2, .class-3-3 {
+  color: #000303;
+  font-size: 15px;
+  margin: 3px;
+  padding: 3px;
+}
+
+.class-4-1, .class-4-2, .class-4-3, .class-4-4 {
+  color: #000404;
+  font-size: 16px;
+  margin: 4px;
+  padding: 4px;
+}
+
+.class-5-1, .class-5-2, .class-5-3, .class-5-4, .class-5-5 {
+  color: #000505;
+  font-size: 17px;
+  margin: 5px;
+  padding: 5px;
+}
+
+.class-6-1, .class-6-2, .class-6-3 {
+  color: #000606;
+  font-size: 18px;
+  margin: 6px;
+  padding: 6px;
+}
+
+.class-7-1, .class-7-2, .class-7-3, .class-7-4 {
+  color: #000707;
+  font-size: 19px;
+  margin: 7px;
+  padding: 7px;
+}
+
+.class-8-1, .class-8-2, .class-8-3, .class-8-4, .class-8-5 {
+  color: #000808;
+  font-size: 12px;
+  margin: 8px;
+  padding: 8px;
+}
+
+.class-9-1, .class-9-2, .class-9-3 {
+  color: #000909;
+  font-size: 13px;
+  margin: 9px;
+  padding: 9px;
+}
+
+.class-10-1, .class-10-2, .class-10-3, .class-10-4 {
+  color: #000a0a;
+  font-size: 14px;
+  margin: 10px;
+  padding: 10px;
+}
+
+.class-11-1, .class-11-2, .class-11-3, .class-11-4, .class-11-5 {
+  color: #000b0b;
+  font-size: 15px;
+  margin: 11px;
+  padding: 11px;
+}
+
+.class-12-1, .class-12-2, .class-12-3 {
+  color: #000c0c;
+  font-size: 16px;
+  margin: 12px;
+  padding: 12px;
+}
+
+.class-13-1, .class-13-2, .class-13-3, .class-13-4 {
+  color: #000d0d;
+  font-size: 17px;
+  margin: 13px;
+  padding: 13px;
+}
+
+.class-14-1, .class-14-2, .class-14-3, .class-14-4, .class-14-5 {
+  color: #000e0e;
+  font-size: 18px;
+  margin: 14px;
+  padding: 14px;
+}
+
+.class-15-1, .class-15-2, .class-15-3 {
+  color: #000f0f;
+  font-size: 19px;
+  margin: 15px;
+  padding: 0px;
+}
+
+.class-16-1, .class-16-2, .class-16-3, .class-16-4 {
+  color: #001010;
+  font-size: 12px;
+  margin: 16px;
+  padding: 1px;
+}
+
+.class-17-1, .class-17-2, .class-17-3, .class-17-4, .class-17-5 {
+  color: #001111;
+  font-size: 13px;
+  margin: 17px;
+  padding: 2px;
+}
+
+.class-18-1, .class-18-2, .class-18-3 {
+  color: #001212;
+  font-size: 14px;
+  margin: 18px;
+  padding: 3px;
+}
+
+.class-19-1, .class-19-2, .class-19-3, .class-19-4 {
+  color: #001313;
+  font-size: 15px;
+  margin: 19px;
+  padding: 4px;
+}
+
+.class-20-1, .class-20-2, .class-20-3, .class-20-4, .class-20-5 {
+  color: #001414;
+  font-size: 16px;
+  margin: 0px;
+  padding: 5px;
+}
+
+.class-21-1, .class-21-2, .class-21-3 {
+  color: #001515;
+  font-size: 17px;
+  margin: 1px;
+  padding: 6px;
+}
+
+.class-22-1, .class-22-2, .class-22-3, .class-22-4 {
+  color: #001616;
+  font-size: 18px;
+  margin: 2px;
+  padding: 7px;
+}
+
+.class-23-1, .class-23-2, .class-23-3, .class-23-4, .class-23-5 {
+  color: #001717;
+  font-size: 19px;
+  margin: 3px;
+  padding: 8px;
+}
+
+.class-24-1, .class-24-2, .class-24-3 {
+  color: #001818;
+  font-size: 12px;
+  margin: 4px;
+  padding: 9px;
+}
+
+.class-25-1, .class-25-2, .class-25-3, .class-25-4 {
+  color: #001919;
+  font-size: 13px;
+  margin: 5px;
+  padding: 10px;
+}
+
+.class-26-1, .class-26-2, .class-26-3, .class-26-4, .class-26-5 {
+  color: #001a1a;
+  font-size: 14px;
+  margin: 6px;
+  padding: 11px;
+}
+
+.class-27-1, .class-27-2, .class-27-3 {
+  color: #001b1b;
+  font-size: 15px;
+  margin: 7px;
+  padding: 12px;
+}
+
+.class-28-1, .class-28-2, .class-28-3, .class-28-4 {
+  color: #001c1c;
+  font-size: 16px;
+  margin: 8px;
+  padding: 13px;
+}
+
+.class-29-1, .class-29-2, .class-29-3, .class-29-4, .class-29-5 {
+  color: #001d1d;
+  font-size: 17px;
+  margin: 9px;
+  padding: 14px;
+}
+
+.class-30-1, .class-30-2, .class-30-3 {
+  color: #001e1e;
+  font-size: 18px;
+  margin: 10px;
+  padding: 0px;
+}
+
+.class-31-1, .class-31-2, .class-31-3, .class-31-4 {
+  color: #001f1f;
+  font-size: 19px;
+  margin: 11px;
+  padding: 1px;
+}
+
+.class-32-1, .class-32-2, .class-32-3, .class-32-4, .class-32-5 {
+  color: #002020;
+  font-size: 12px;
+  margin: 12px;
+  padding: 2px;
+}
+
+.class-33-1, .class-33-2, .class-33-3 {
+  color: #002121;
+  font-size: 13px;
+  margin: 13px;
+  padding: 3px;
+}
+
+.class-34-1, .class-34-2, .class-34-3, .class-34-4 {
+  color: #002222;
+  font-size: 14px;
+  margin: 14px;
+  padding: 4px;
+}
+
+.class-35-1, .class-35-2, .class-35-3, .class-35-4, .class-35-5 {
+  color: #002323;
+  font-size: 15px;
+  margin: 15px;
+  padding: 5px;
+}
+
+.class-36-1, .class-36-2, .class-36-3 {
+  color: #002424;
+  font-size: 16px;
+  margin: 16px;
+  padding: 6px;
+}
+
+.class-37-1, .class-37-2, .class-37-3, .class-37-4 {
+  color: #002525;
+  font-size: 17px;
+  margin: 17px;
+  padding: 7px;
+}
+
+.class-38-1, .class-38-2, .class-38-3, .class-38-4, .class-38-5 {
+  color: #002626;
+  font-size: 18px;
+  margin: 18px;
+  padding: 8px;
+}
+
+.class-39-1, .class-39-2, .class-39-3 {
+  color: #002727;
+  font-size: 19px;
+  margin: 19px;
+  padding: 9px;
+}
+
+.class-40-1, .class-40-2, .class-40-3, .class-40-4 {
+  color: #002828;
+  font-size: 12px;
+  margin: 0px;
+  padding: 10px;
+}
+
+.class-41-1, .class-41-2, .class-41-3, .class-41-4, .class-41-5 {
+  color: #002929;
+  font-size: 13px;
+  margin: 1px;
+  padding: 11px;
+}
+
+.class-42-1, .class-42-2, .class-42-3 {
+  color: #002a2a;
+  font-size: 14px;
+  margin: 2px;
+  padding: 12px;
+}
+
+.class-43-1, .class-43-2, .class-43-3, .class-43-4 {
+  color: #002b2b;
+  font-size: 15px;
+  margin: 3px;
+  padding: 13px;
+}
+
+.class-44-1, .class-44-2, .class-44-3, .class-44-4, .class-44-5 {
+  color: #002c2c;
+  font-size: 16px;
+  margin: 4px;
+  padding: 14px;
+}
+
+.class-45-1, .class-45-2, .class-45-3 {
+  color: #002d2d;
+  font-size: 17px;
+  margin: 5px;
+  padding: 0px;
+}
+
+.class-46-1, .class-46-2, .class-46-3, .class-46-4 {
+  color: #002e2e;
+  font-size: 18px;
+  margin: 6px;
+  padding: 1px;
+}
+
+.class-47-1, .class-47-2, .class-47-3, .class-47-4, .class-47-5 {
+  color: #002f2f;
+  font-size: 19px;
+  margin: 7px;
+  padding: 2px;
+}
+
+.class-48-1, .class-48-2, .class-48-3 {
+  color: #003030;
+  font-size: 12px;
+  margin: 8px;
+  padding: 3px;
+}
+
+.class-49-1, .class-49-2, .class-49-3, .class-49-4 {
+  color: #003131;
+  font-size: 13px;
+  margin: 9px;
+  padding: 4px;
+}
+
+.class-50-1, .class-50-2, .class-50-3, .class-50-4, .class-50-5 {
+  color: #003232;
+  font-size: 14px;
+  margin: 10px;
+  padding: 5px;
+}
+
+.class-51-1, .class-51-2, .class-51-3 {
+  color: #003333;
+  font-size: 15px;
+  margin: 11px;
+  padding: 6px;
+}
+
+.class-52-1, .class-52-2, .class-52-3, .class-52-4 {
+  color: #003434;
+  font-size: 16px;
+  margin: 12px;
+  padding: 7px;
+}
+
+.class-53-1, .class-53-2, .class-53-3, .class-53-4, .class-53-5 {
+  color: #003535;
+  font-size: 17px;
+  margin: 13px;
+  padding: 8px;
+}
+
+.class-54-1, .class-54-2, .class-54-3 {
+  color: #003636;
+  font-size: 18px;
+  margin: 14px;
+  padding: 9px;
+}
+
+.class-55-1, .class-55-2, .class-55-3, .class-55-4 {
+  color: #003737;
+  font-size: 19px;
+  margin: 15px;
+  padding: 10px;
+}
+
+.class-56-1, .class-56-2, .class-56-3, .class-56-4, .class-56-5 {
+  color: #003838;
+  font-size: 12px;
+  margin: 16px;
+  padding: 11px;
+}
+
+.class-57-1, .class-57-2, .class-57-3 {
+  color: #003939;
+  font-size: 13px;
+  margin: 17px;
+  padding: 12px;
+}
+
+.class-58-1, .class-58-2, .class-58-3, .class-58-4 {
+  color: #003a3a;
+  font-size: 14px;
+  margin: 18px;
+  padding: 13px;
+}
+
+.class-59-1, .class-59-2, .class-59-3, .class-59-4, .class-59-5 {
+  color: #003b3b;
+  font-size: 15px;
+  margin: 19px;
+  padding: 14px;
+}
+
+.class-60-1, .class-60-2, .class-60-3 {
+  color: #003c3c;
+  font-size: 16px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.class-61-1, .class-61-2, .class-61-3, .class-61-4 {
+  color: #003d3d;
+  font-size: 17px;
+  margin: 1px;
+  padding: 1px;
+}
+
+.class-62-1, .class-62-2, .class-62-3, .class-62-4, .class-62-5 {
+  color: #003e3e;
+  font-size: 18px;
+  margin: 2px;
+  padding: 2px;
+}
+
+.class-63-1, .class-63-2, .class-63-3 {
+  color: #003f3f;
+  font-size: 19px;
+  margin: 3px;
+  padding: 3px;
+}
+
+.class-64-1, .class-64-2, .class-64-3, .class-64-4 {
+  color: #004040;
+  font-size: 12px;
+  margin: 4px;
+  padding: 4px;
+}
+
+.class-65-1, .class-65-2, .class-65-3, .class-65-4, .class-65-5 {
+  color: #004141;
+  font-size: 13px;
+  margin: 5px;
+  padding: 5px;
+}
+
+.class-66-1, .class-66-2, .class-66-3 {
+  color: #004242;
+  font-size: 14px;
+  margin: 6px;
+  padding: 6px;
+}
+
+.class-67-1, .class-67-2, .class-67-3, .class-67-4 {
+  color: #004343;
+  font-size: 15px;
+  margin: 7px;
+  padding: 7px;
+}
+
+.class-68-1, .class-68-2, .class-68-3, .class-68-4, .class-68-5 {
+  color: #004444;
+  font-size: 16px;
+  margin: 8px;
+  padding: 8px;
+}
+
+.class-69-1, .class-69-2, .class-69-3 {
+  color: #004545;
+  font-size: 17px;
+  margin: 9px;
+  padding: 9px;
+}
+
+.class-70-1, .class-70-2, .class-70-3, .class-70-4 {
+  color: #004646;
+  font-size: 18px;
+  margin: 10px;
+  padding: 10px;
+}
+
+.class-71-1, .class-71-2, .class-71-3, .class-71-4, .class-71-5 {
+  color: #004747;
+  font-size: 19px;
+  margin: 11px;
+  padding: 11px;
+}
+
+.class-72-1, .class-72-2, .class-72-3 {
+  color: #004848;
+  font-size: 12px;
+  margin: 12px;
+  padding: 12px;
+}
+
+.class-73-1, .class-73-2, .class-73-3, .class-73-4 {
+  color: #004949;
+  font-size: 13px;
+  margin: 13px;
+  padding: 13px;
+}
+
+.class-74-1, .class-74-2, .class-74-3, .class-74-4, .class-74-5 {
+  color: #004a4a;
+  font-size: 14px;
+  margin: 14px;
+  padding: 14px;
+}
+
+.class-75-1, .class-75-2, .class-75-3 {
+  color: #004b4b;
+  font-size: 15px;
+  margin: 15px;
+  padding: 0px;
+}
+
+.class-76-1, .class-76-2, .class-76-3, .class-76-4 {
+  color: #004c4c;
+  font-size: 16px;
+  margin: 16px;
+  padding: 1px;
+}
+
+.class-77-1, .class-77-2, .class-77-3, .class-77-4, .class-77-5 {
+  color: #004d4d;
+  font-size: 17px;
+  margin: 17px;
+  padding: 2px;
+}
+
+.class-78-1, .class-78-2, .class-78-3 {
+  color: #004e4e;
+  font-size: 18px;
+  margin: 18px;
+  padding: 3px;
+}
+
+.class-79-1, .class-79-2, .class-79-3, .class-79-4 {
+  color: #004f4f;
+  font-size: 19px;
+  margin: 19px;
+  padding: 4px;
+}
+
+.class-80-1, .class-80-2, .class-80-3, .class-80-4, .class-80-5 {
+  color: #005050;
+  font-size: 12px;
+  margin: 0px;
+  padding: 5px;
+}
+
+.class-81-1, .class-81-2, .class-81-3 {
+  color: #005151;
+  font-size: 13px;
+  margin: 1px;
+  padding: 6px;
+}
+
+.class-82-1, .class-82-2, .class-82-3, .class-82-4 {
+  color: #005252;
+  font-size: 14px;
+  margin: 2px;
+  padding: 7px;
+}
+
+.class-83-1, .class-83-2, .class-83-3, .class-83-4, .class-83-5 {
+  color: #005353;
+  font-size: 15px;
+  margin: 3px;
+  padding: 8px;
+}
+
+.class-84-1, .class-84-2, .class-84-3 {
+  color: #005454;
+  font-size: 16px;
+  margin: 4px;
+  padding: 9px;
+}
+
+.class-85-1, .class-85-2, .class-85-3, .class-85-4 {
+  color: #005555;
+  font-size: 17px;
+  margin: 5px;
+  padding: 10px;
+}
+
+.class-86-1, .class-86-2, .class-86-3, .class-86-4, .class-86-5 {
+  color: #005656;
+  font-size: 18px;
+  margin: 6px;
+  padding: 11px;
+}
+
+.class-87-1, .class-87-2, .class-87-3 {
+  color: #005757;
+  font-size: 19px;
+  margin: 7px;
+  padding: 12px;
+}
+
+.class-88-1, .class-88-2, .class-88-3, .class-88-4 {
+  color: #005858;
+  font-size: 12px;
+  margin: 8px;
+  padding: 13px;
+}
+
+.class-89-1, .class-89-2, .class-89-3, .class-89-4, .class-89-5 {
+  color: #005959;
+  font-size: 13px;
+  margin: 9px;
+  padding: 14px;
+}
+
+.class-90-1, .class-90-2, .class-90-3 {
+  color: #005a5a;
+  font-size: 14px;
+  margin: 10px;
+  padding: 0px;
+}
+
+.class-91-1, .class-91-2, .class-91-3, .class-91-4 {
+  color: #005b5b;
+  font-size: 15px;
+  margin: 11px;
+  padding: 1px;
+}
+
+.class-92-1, .class-92-2, .class-92-3, .class-92-4, .class-92-5 {
+  color: #005c5c;
+  font-size: 16px;
+  margin: 12px;
+  padding: 2px;
+}
+
+.class-93-1, .class-93-2, .class-93-3 {
+  color: #005d5d;
+  font-size: 17px;
+  margin: 13px;
+  padding: 3px;
+}
+
+.class-94-1, .class-94-2, .class-94-3, .class-94-4 {
+  color: #005e5e;
+  font-size: 18px;
+  margin: 14px;
+  padding: 4px;
+}
+
+.class-95-1, .class-95-2, .class-95-3, .class-95-4, .class-95-5 {
+  color: #005f5f;
+  font-size: 19px;
+  margin: 15px;
+  padding: 5px;
+}
+
+.class-96-1, .class-96-2, .class-96-3 {
+  color: #006060;
+  font-size: 12px;
+  margin: 16px;
+  padding: 6px;
+}
+
+.class-97-1, .class-97-2, .class-97-3, .class-97-4 {
+  color: #006161;
+  font-size: 13px;
+  margin: 17px;
+  padding: 7px;
+}
+
+.class-98-1, .class-98-2, .class-98-3, .class-98-4, .class-98-5 {
+  color: #006262;
+  font-size: 14px;
+  margin: 18px;
+  padding: 8px;
+}
+
+.class-99-1, .class-99-2, .class-99-3 {
+  color: #006363;
+  font-size: 15px;
+  margin: 19px;
+  padding: 9px;
+}
+
+.class-100-1, .class-100-2, .class-100-3, .class-100-4 {
+  color: #006464;
+  font-size: 16px;
+  margin: 0px;
+  padding: 10px;
+}
+
+.class-101-1, .class-101-2, .class-101-3, .class-101-4, .class-101-5 {
+  color: #006565;
+  font-size: 17px;
+  margin: 1px;
+  padding: 11px;
+}
+
+.class-102-1, .class-102-2, .class-102-3 {
+  color: #006666;
+  font-size: 18px;
+  margin: 2px;
+  padding: 12px;
+}
+
+.class-103-1, .class-103-2, .class-103-3, .class-103-4 {
+  color: #006767;
+  font-size: 19px;
+  margin: 3px;
+  padding: 13px;
+}
+
+.class-104-1, .class-104-2, .class-104-3, .class-104-4, .class-104-5 {
+  color: #006868;
+  font-size: 12px;
+  margin: 4px;
+  padding: 14px;
+}
+
+.class-105-1, .class-105-2, .class-105-3 {
+  color: #006969;
+  font-size: 13px;
+  margin: 5px;
+  padding: 0px;
+}
+
+.class-106-1, .class-106-2, .class-106-3, .class-106-4 {
+  color: #006a6a;
+  font-size: 14px;
+  margin: 6px;
+  padding: 1px;
+}
+
+.class-107-1, .class-107-2, .class-107-3, .class-107-4, .class-107-5 {
+  color: #006b6b;
+  font-size: 15px;
+  margin: 7px;
+  padding: 2px;
+}
+
+.class-108-1, .class-108-2, .class-108-3 {
+  color: #006c6c;
+  font-size: 16px;
+  margin: 8px;
+  padding: 3px;
+}
+
+.class-109-1, .class-109-2, .class-109-3, .class-109-4 {
+  color: #006d6d;
+  font-size: 17px;
+  margin: 9px;
+  padding: 4px;
+}
+
+.class-110-1, .class-110-2, .class-110-3, .class-110-4, .class-110-5 {
+  color: #006e6e;
+  font-size: 18px;
+  margin: 10px;
+  padding: 5px;
+}
+
+.class-111-1, .class-111-2, .class-111-3 {
+  color: #006f6f;
+  font-size: 19px;
+  margin: 11px;
+  padding: 6px;
+}
+
+.class-112-1, .class-112-2, .class-112-3, .class-112-4 {
+  color: #007070;
+  font-size: 12px;
+  margin: 12px;
+  padding: 7px;
+}
+
+.class-113-1, .class-113-2, .class-113-3, .class-113-4, .class-113-5 {
+  color: #007171;
+  font-size: 13px;
+  margin: 13px;
+  padding: 8px;
+}
+
+.class-114-1, .class-114-2, .class-114-3 {
+  color: #007272;
+  font-size: 14px;
+  margin: 14px;
+  padding: 9px;
+}
+
+.class-115-1, .class-115-2, .class-115-3, .class-115-4 {
+  color: #007373;
+  font-size: 15px;
+  margin: 15px;
+  padding: 10px;
+}
+
+.class-116-1, .class-116-2, .class-116-3, .class-116-4, .class-116-5 {
+  color: #007474;
+  font-size: 16px;
+  margin: 16px;
+  padding: 11px;
+}
+
+.class-117-1, .class-117-2, .class-117-3 {
+  color: #007575;
+  font-size: 17px;
+  margin: 17px;
+  padding: 12px;
+}
+
+.class-118-1, .class-118-2, .class-118-3, .class-118-4 {
+  color: #007676;
+  font-size: 18px;
+  margin: 18px;
+  padding: 13px;
+}
+
+.class-119-1, .class-119-2, .class-119-3, .class-119-4, .class-119-5 {
+  color: #007777;
+  font-size: 19px;
+  margin: 19px;
+  padding: 14px;
+}
+
+.class-120-1, .class-120-2, .class-120-3 {
+  color: #007878;
+  font-size: 12px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.class-121-1, .class-121-2, .class-121-3, .class-121-4 {
+  color: #007979;
+  font-size: 13px;
+  margin: 1px;
+  padding: 1px;
+}
+
+.class-122-1, .class-122-2, .class-122-3, .class-122-4, .class-122-5 {
+  color: #007a7a;
+  font-size: 14px;
+  margin: 2px;
+  padding: 2px;
+}
+
+.class-123-1, .class-123-2, .class-123-3 {
+  color: #007b7b;
+  font-size: 15px;
+  margin: 3px;
+  padding: 3px;
+}
+
+.class-124-1, .class-124-2, .class-124-3, .class-124-4 {
+  color: #007c7c;
+  font-size: 16px;
+  margin: 4px;
+  padding: 4px;
+}
+
+.class-125-1, .class-125-2, .class-125-3, .class-125-4, .class-125-5 {
+  color: #007d7d;
+  font-size: 17px;
+  margin: 5px;
+  padding: 5px;
+}
+
+.class-126-1, .class-126-2, .class-126-3 {
+  color: #007e7e;
+  font-size: 18px;
+  margin: 6px;
+  padding: 6px;
+}
+
+.class-127-1, .class-127-2, .class-127-3, .class-127-4 {
+  color: #007f7f;
+  font-size: 19px;
+  margin: 7px;
+  padding: 7px;
+}
+
+.class-128-1, .class-128-2, .class-128-3, .class-128-4, .class-128-5 {
+  color: #008080;
+  font-size: 12px;
+  margin: 8px;
+  padding: 8px;
+}
+
+.class-129-1, .class-129-2, .class-129-3 {
+  color: #008181;
+  font-size: 13px;
+  margin: 9px;
+  padding: 9px;
+}
+
+.class-130-1, .class-130-2, .class-130-3, .class-130-4 {
+  color: #008282;
+  font-size: 14px;
+  margin: 10px;
+  padding: 10px;
+}
+
+.class-131-1, .class-131-2, .class-131-3, .class-131-4, .class-131-5 {
+  color: #008383;
+  font-size: 15px;
+  margin: 11px;
+  padding: 11px;
+}
+
+.class-132-1, .class-132-2, .class-132-3 {
+  color: #008484;
+  font-size: 16px;
+  margin: 12px;
+  padding: 12px;
+}
+
+.class-133-1, .class-133-2, .class-133-3, .class-133-4 {
+  color: #008585;
+  font-size: 17px;
+  margin: 13px;
+  padding: 13px;
+}
+
+.class-134-1, .class-134-2, .class-134-3, .class-134-4, .class-134-5 {
+  color: #008686;
+  font-size: 18px;
+  margin: 14px;
+  padding: 14px;
+}
+
+.class-135-1, .class-135-2, .class-135-3 {
+  color: #008787;
+  font-size: 19px;
+  margin: 15px;
+  padding: 0px;
+}
+
+.class-136-1, .class-136-2, .class-136-3, .class-136-4 {
+  color: #008888;
+  font-size: 12px;
+  margin: 16px;
+  padding: 1px;
+}
+
+.class-137-1, .class-137-2, .class-137-3, .class-137-4, .class-137-5 {
+  color: #008989;
+  font-size: 13px;
+  margin: 17px;
+  padding: 2px;
+}
+
+.class-138-1, .class-138-2, .class-138-3 {
+  color: #008a8a;
+  font-size: 14px;
+  margin: 18px;
+  padding: 3px;
+}
+
+.class-139-1, .class-139-2, .class-139-3, .class-139-4 {
+  color: #008b8b;
+  font-size: 15px;
+  margin: 19px;
+  padding: 4px;
+}
+
+.class-140-1, .class-140-2, .class-140-3, .class-140-4, .class-140-5 {
+  color: #008c8c;
+  font-size: 16px;
+  margin: 0px;
+  padding: 5px;
+}
+
+.class-141-1, .class-141-2, .class-141-3 {
+  color: #008d8d;
+  font-size: 17px;
+  margin: 1px;
+  padding: 6px;
+}
+
+.class-142-1, .class-142-2, .class-142-3, .class-142-4 {
+  color: #008e8e;
+  font-size: 18px;
+  margin: 2px;
+  padding: 7px;
+}
+
+.class-143-1, .class-143-2, .class-143-3, .class-143-4, .class-143-5 {
+  color: #008f8f;
+  font-size: 19px;
+  margin: 3px;
+  padding: 8px;
+}
+
+.class-144-1, .class-144-2, .class-144-3 {
+  color: #009090;
+  font-size: 12px;
+  margin: 4px;
+  padding: 9px;
+}
+
+.class-145-1, .class-145-2, .class-145-3, .class-145-4 {
+  color: #009191;
+  font-size: 13px;
+  margin: 5px;
+  padding: 10px;
+}
+
+.class-146-1, .class-146-2, .class-146-3, .class-146-4, .class-146-5 {
+  color: #009292;
+  font-size: 14px;
+  margin: 6px;
+  padding: 11px;
+}
+
+.class-147-1, .class-147-2, .class-147-3 {
+  color: #009393;
+  font-size: 15px;
+  margin: 7px;
+  padding: 12px;
+}
+
+.class-148-1, .class-148-2, .class-148-3, .class-148-4 {
+  color: #009494;
+  font-size: 16px;
+  margin: 8px;
+  padding: 13px;
+}
+
+.class-149-1, .class-149-2, .class-149-3, .class-149-4, .class-149-5 {
+  color: #009595;
+  font-size: 17px;
+  margin: 9px;
+  padding: 14px;
+}
+
+.class-150-1, .class-150-2, .class-150-3 {
+  color: #009696;
+  font-size: 18px;
+  margin: 10px;
+  padding: 0px;
+}
+
+.class-151-1, .class-151-2, .class-151-3, .class-151-4 {
+  color: #009797;
+  font-size: 19px;
+  margin: 11px;
+  padding: 1px;
+}
+
+.class-152-1, .class-152-2, .class-152-3, .class-152-4, .class-152-5 {
+  color: #009898;
+  font-size: 12px;
+  margin: 12px;
+  padding: 2px;
+}
+
+.class-153-1, .class-153-2, .class-153-3 {
+  color: #009999;
+  font-size: 13px;
+  margin: 13px;
+  padding: 3px;
+}
+
+.class-154-1, .class-154-2, .class-154-3, .class-154-4 {
+  color: #009a9a;
+  font-size: 14px;
+  margin: 14px;
+  padding: 4px;
+}
+
+.class-155-1, .class-155-2, .class-155-3, .class-155-4, .class-155-5 {
+  color: #009b9b;
+  font-size: 15px;
+  margin: 15px;
+  padding: 5px;
+}
+
+.class-156-1, .class-156-2, .class-156-3 {
+  color: #009c9c;
+  font-size: 16px;
+  margin: 16px;
+  padding: 6px;
+}
+
+.class-157-1, .class-157-2, .class-157-3, .class-157-4 {
+  color: #009d9d;
+  font-size: 17px;
+  margin: 17px;
+  padding: 7px;
+}
+
+.class-158-1, .class-158-2, .class-158-3, .class-158-4, .class-158-5 {
+  color: #009e9e;
+  font-size: 18px;
+  margin: 18px;
+  padding: 8px;
+}
+
+.class-159-1, .class-159-2, .class-159-3 {
+  color: #009f9f;
+  font-size: 19px;
+  margin: 19px;
+  padding: 9px;
+}
+
+.class-160-1, .class-160-2, .class-160-3, .class-160-4 {
+  color: #00a0a0;
+  font-size: 12px;
+  margin: 0px;
+  padding: 10px;
+}
+
+.class-161-1, .class-161-2, .class-161-3, .class-161-4, .class-161-5 {
+  color: #00a1a1;
+  font-size: 13px;
+  margin: 1px;
+  padding: 11px;
+}
+
+.class-162-1, .class-162-2, .class-162-3 {
+  color: #00a2a2;
+  font-size: 14px;
+  margin: 2px;
+  padding: 12px;
+}
+
+.class-163-1, .class-163-2, .class-163-3, .class-163-4 {
+  color: #00a3a3;
+  font-size: 15px;
+  margin: 3px;
+  padding: 13px;
+}
+
+.class-164-1, .class-164-2, .class-164-3, .class-164-4, .class-164-5 {
+  color: #00a4a4;
+  font-size: 16px;
+  margin: 4px;
+  padding: 14px;
+}
+
+.class-165-1, .class-165-2, .class-165-3 {
+  color: #00a5a5;
+  font-size: 17px;
+  margin: 5px;
+  padding: 0px;
+}
+
+.class-166-1, .class-166-2, .class-166-3, .class-166-4 {
+  color: #00a6a6;
+  font-size: 18px;
+  margin: 6px;
+  padding: 1px;
+}
+
+.class-167-1, .class-167-2, .class-167-3, .class-167-4, .class-167-5 {
+  color: #00a7a7;
+  font-size: 19px;
+  margin: 7px;
+  padding: 2px;
+}
+
+.class-168-1, .class-168-2, .class-168-3 {
+  color: #00a8a8;
+  font-size: 12px;
+  margin: 8px;
+  padding: 3px;
+}
+
+.class-169-1, .class-169-2, .class-169-3, .class-169-4 {
+  color: #00a9a9;
+  font-size: 13px;
+  margin: 9px;
+  padding: 4px;
+}
+
+.class-170-1, .class-170-2, .class-170-3, .class-170-4, .class-170-5 {
+  color: #00aaaa;
+  font-size: 14px;
+  margin: 10px;
+  padding: 5px;
+}
+
+.class-171-1, .class-171-2, .class-171-3 {
+  color: #00abab;
+  font-size: 15px;
+  margin: 11px;
+  padding: 6px;
+}
+
+.class-172-1, .class-172-2, .class-172-3, .class-172-4 {
+  color: #00acac;
+  font-size: 16px;
+  margin: 12px;
+  padding: 7px;
+}
+
+.class-173-1, .class-173-2, .class-173-3, .class-173-4, .class-173-5 {
+  color: #00adad;
+  font-size: 17px;
+  margin: 13px;
+  padding: 8px;
+}
+
+.class-174-1, .class-174-2, .class-174-3 {
+  color: #00aeae;
+  font-size: 18px;
+  margin: 14px;
+  padding: 9px;
+}
+
+.class-175-1, .class-175-2, .class-175-3, .class-175-4 {
+  color: #00afaf;
+  font-size: 19px;
+  margin: 15px;
+  padding: 10px;
+}
+
+.class-176-1, .class-176-2, .class-176-3, .class-176-4, .class-176-5 {
+  color: #00b0b0;
+  font-size: 12px;
+  margin: 16px;
+  padding: 11px;
+}
+
+.class-177-1, .class-177-2, .class-177-3 {
+  color: #00b1b1;
+  font-size: 13px;
+  margin: 17px;
+  padding: 12px;
+}
+
+.class-178-1, .class-178-2, .class-178-3, .class-178-4 {
+  color: #00b2b2;
+  font-size: 14px;
+  margin: 18px;
+  padding: 13px;
+}
+
+.class-179-1, .class-179-2, .class-179-3, .class-179-4, .class-179-5 {
+  color: #00b3b3;
+  font-size: 15px;
+  margin: 19px;
+  padding: 14px;
+}
+
+.class-180-1, .class-180-2, .class-180-3 {
+  color: #00b4b4;
+  font-size: 16px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.class-181-1, .class-181-2, .class-181-3, .class-181-4 {
+  color: #00b5b5;
+  font-size: 17px;
+  margin: 1px;
+  padding: 1px;
+}
+
+.class-182-1, .class-182-2, .class-182-3, .class-182-4, .class-182-5 {
+  color: #00b6b6;
+  font-size: 18px;
+  margin: 2px;
+  padding: 2px;
+}
+
+.class-183-1, .class-183-2, .class-183-3 {
+  color: #00b7b7;
+  font-size: 19px;
+  margin: 3px;
+  padding: 3px;
+}
+
+.class-184-1, .class-184-2, .class-184-3, .class-184-4 {
+  color: #00b8b8;
+  font-size: 12px;
+  margin: 4px;
+  padding: 4px;
+}
+
+.class-185-1, .class-185-2, .class-185-3, .class-185-4, .class-185-5 {
+  color: #00b9b9;
+  font-size: 13px;
+  margin: 5px;
+  padding: 5px;
+}
+
+.class-186-1, .class-186-2, .class-186-3 {
+  color: #00baba;
+  font-size: 14px;
+  margin: 6px;
+  padding: 6px;
+}
+
+.class-187-1, .class-187-2, .class-187-3, .class-187-4 {
+  color: #00bbbb;
+  font-size: 15px;
+  margin: 7px;
+  padding: 7px;
+}
+
+.class-188-1, .class-188-2, .class-188-3, .class-188-4, .class-188-5 {
+  color: #00bcbc;
+  font-size: 16px;
+  margin: 8px;
+  padding: 8px;
+}
+
+.class-189-1, .class-189-2, .class-189-3 {
+  color: #00bdbd;
+  font-size: 17px;
+  margin: 9px;
+  padding: 9px;
+}
+
+.class-190-1, .class-190-2, .class-190-3, .class-190-4 {
+  color: #00bebe;
+  font-size: 18px;
+  margin: 10px;
+  padding: 10px;
+}
+
+.class-191-1, .class-191-2, .class-191-3, .class-191-4, .class-191-5 {
+  color: #00bfbf;
+  font-size: 19px;
+  margin: 11px;
+  padding: 11px;
+}
+
+.class-192-1, .class-192-2, .class-192-3 {
+  color: #00c0c0;
+  font-size: 12px;
+  margin: 12px;
+  padding: 12px;
+}
+
+.class-193-1, .class-193-2, .class-193-3, .class-193-4 {
+  color: #00c1c1;
+  font-size: 13px;
+  margin: 13px;
+  padding: 13px;
+}
+
+.class-194-1, .class-194-2, .class-194-3, .class-194-4, .class-194-5 {
+  color: #00c2c2;
+  font-size: 14px;
+  margin: 14px;
+  padding: 14px;
+}
+
+.class-195-1, .class-195-2, .class-195-3 {
+  color: #00c3c3;
+  font-size: 15px;
+  margin: 15px;
+  padding: 0px;
+}
+
+.class-196-1, .class-196-2, .class-196-3, .class-196-4 {
+  color: #00c4c4;
+  font-size: 16px;
+  margin: 16px;
+  padding: 1px;
+}
+
+.class-197-1, .class-197-2, .class-197-3, .class-197-4, .class-197-5 {
+  color: #00c5c5;
+  font-size: 17px;
+  margin: 17px;
+  padding: 2px;
+}
+
+.class-198-1, .class-198-2, .class-198-3 {
+  color: #00c6c6;
+  font-size: 18px;
+  margin: 18px;
+  padding: 3px;
+}
+
+.class-199-1, .class-199-2, .class-199-3, .class-199-4 {
+  color: #00c7c7;
+  font-size: 19px;
+  margin: 19px;
+  padding: 4px;
+}
+
+.class-200-1, .class-200-2, .class-200-3, .class-200-4, .class-200-5 {
+  color: #00c8c8;
+  font-size: 12px;
+  margin: 0px;
+  padding: 5px;
+}
+
+.class-201-1, .class-201-2, .class-201-3 {
+  color: #00c9c9;
+  font-size: 13px;
+  margin: 1px;
+  padding: 6px;
+}
+
+.class-202-1, .class-202-2, .class-202-3, .class-202-4 {
+  color: #00caca;
+  font-size: 14px;
+  margin: 2px;
+  padding: 7px;
+}
+
+.class-203-1, .class-203-2, .class-203-3, .class-203-4, .class-203-5 {
+  color: #00cbcb;
+  font-size: 15px;
+  margin: 3px;
+  padding: 8px;
+}
+
+.class-204-1, .class-204-2, .class-204-3 {
+  color: #00cccc;
+  font-size: 16px;
+  margin: 4px;
+  padding: 9px;
+}
+
+.class-205-1, .class-205-2, .class-205-3, .class-205-4 {
+  color: #00cdcd;
+  font-size: 17px;
+  margin: 5px;
+  padding: 10px;
+}
+
+.class-206-1, .class-206-2, .class-206-3, .class-206-4, .class-206-5 {
+  color: #00cece;
+  font-size: 18px;
+  margin: 6px;
+  padding: 11px;
+}
+
+.class-207-1, .class-207-2, .class-207-3 {
+  color: #00cfcf;
+  font-size: 19px;
+  margin: 7px;
+  padding: 12px;
+}
+
+.class-208-1, .class-208-2, .class-208-3, .class-208-4 {
+  color: #00d0d0;
+  font-size: 12px;
+  margin: 8px;
+  padding: 13px;
+}
+
+.class-209-1, .class-209-2, .class-209-3, .class-209-4, .class-209-5 {
+  color: #00d1d1;
+  font-size: 13px;
+  margin: 9px;
+  padding: 14px;
+}
+
+.class-210-1, .class-210-2, .class-210-3 {
+  color: #00d2d2;
+  font-size: 14px;
+  margin: 10px;
+  padding: 0px;
+}
+
+.class-211-1, .class-211-2, .class-211-3, .class-211-4 {
+  color: #00d3d3;
+  font-size: 15px;
+  margin: 11px;
+  padding: 1px;
+}
+
+.class-212-1, .class-212-2, .class-212-3, .class-212-4, .class-212-5 {
+  color: #00d4d4;
+  font-size: 16px;
+  margin: 12px;
+  padding: 2px;
+}
+
+.class-213-1, .class-213-2, .class-213-3 {
+  color: #00d5d5;
+  font-size: 17px;
+  margin: 13px;
+  padding: 3px;
+}
+
+.class-214-1, .class-214-2, .class-214-3, .class-214-4 {
+  color: #00d6d6;
+  font-size: 18px;
+  margin: 14px;
+  padding: 4px;
+}
+
+.class-215-1, .class-215-2, .class-215-3, .class-215-4, .class-215-5 {
+  color: #00d7d7;
+  font-size: 19px;
+  margin: 15px;
+  padding: 5px;
+}
+
+.class-216-1, .class-216-2, .class-216-3 {
+  color: #00d8d8;
+  font-size: 12px;
+  margin: 16px;
+  padding: 6px;
+}
+
+.class-217-1, .class-217-2, .class-217-3, .class-217-4 {
+  color: #00d9d9;
+  font-size: 13px;
+  margin: 17px;
+  padding: 7px;
+}
+
+.class-218-1, .class-218-2, .class-218-3, .class-218-4, .class-218-5 {
+  color: #00dada;
+  font-size: 14px;
+  margin: 18px;
+  padding: 8px;
+}
+
+.class-219-1, .class-219-2, .class-219-3 {
+  color: #00dbdb;
+  font-size: 15px;
+  margin: 19px;
+  padding: 9px;
+}
+
+.class-220-1, .class-220-2, .class-220-3, .class-220-4 {
+  color: #00dcdc;
+  font-size: 16px;
+  margin: 0px;
+  padding: 10px;
+}
+
+.class-221-1, .class-221-2, .class-221-3, .class-221-4, .class-221-5 {
+  color: #00dddd;
+  font-size: 17px;
+  margin: 1px;
+  padding: 11px;
+}
+
+.class-222-1, .class-222-2, .class-222-3 {
+  color: #00dede;
+  font-size: 18px;
+  margin: 2px;
+  padding: 12px;
+}
+
+.class-223-1, .class-223-2, .class-223-3, .class-223-4 {
+  color: #00dfdf;
+  font-size: 19px;
+  margin: 3px;
+  padding: 13px;
+}
+
+.class-224-1, .class-224-2, .class-224-3, .class-224-4, .class-224-5 {
+  color: #00e0e0;
+  font-size: 12px;
+  margin: 4px;
+  padding: 14px;
+}
+
+.class-225-1, .class-225-2, .class-225-3 {
+  color: #00e1e1;
+  font-size: 13px;
+  margin: 5px;
+  padding: 0px;
+}
+
+.class-226-1, .class-226-2, .class-226-3, .class-226-4 {
+  color: #00e2e2;
+  font-size: 14px;
+  margin: 6px;
+  padding: 1px;
+}
+
+.class-227-1, .class-227-2, .class-227-3, .class-227-4, .class-227-5 {
+  color: #00e3e3;
+  font-size: 15px;
+  margin: 7px;
+  padding: 2px;
+}
+
+.class-228-1, .class-228-2, .class-228-3 {
+  color: #00e4e4;
+  font-size: 16px;
+  margin: 8px;
+  padding: 3px;
+}
+
+.class-229-1, .class-229-2, .class-229-3, .class-229-4 {
+  color: #00e5e5;
+  font-size: 17px;
+  margin: 9px;
+  padding: 4px;
+}
+
+.class-230-1, .class-230-2, .class-230-3, .class-230-4, .class-230-5 {
+  color: #00e6e6;
+  font-size: 18px;
+  margin: 10px;
+  padding: 5px;
+}
+
+.class-231-1, .class-231-2, .class-231-3 {
+  color: #00e7e7;
+  font-size: 19px;
+  margin: 11px;
+  padding: 6px;
+}
+
+.class-232-1, .class-232-2, .class-232-3, .class-232-4 {
+  color: #00e8e8;
+  font-size: 12px;
+  margin: 12px;
+  padding: 7px;
+}
+
+.class-233-1, .class-233-2, .class-233-3, .class-233-4, .class-233-5 {
+  color: #00e9e9;
+  font-size: 13px;
+  margin: 13px;
+  padding: 8px;
+}
+
+.class-234-1, .class-234-2, .class-234-3 {
+  color: #00eaea;
+  font-size: 14px;
+  margin: 14px;
+  padding: 9px;
+}
+
+.class-235-1, .class-235-2, .class-235-3, .class-235-4 {
+  color: #00ebeb;
+  font-size: 15px;
+  margin: 15px;
+  padding: 10px;
+}
+
+.class-236-1, .class-236-2, .class-236-3, .class-236-4, .class-236-5 {
+  color: #00ecec;
+  font-size: 16px;
+  margin: 16px;
+  padding: 11px;
+}
+
+.class-237-1, .class-237-2, .class-237-3 {
+  color: #00eded;
+  font-size: 17px;
+  margin: 17px;
+  padding: 12px;
+}
+
+.class-238-1, .class-238-2, .class-238-3, .class-238-4 {
+  color: #00eeee;
+  font-size: 18px;
+  margin: 18px;
+  padding: 13px;
+}
+
+.class-239-1, .class-239-2, .class-239-3, .class-239-4, .class-239-5 {
+  color: #00efef;
+  font-size: 19px;
+  margin: 19px;
+  padding: 14px;
+}
+
+.class-240-1, .class-240-2, .class-240-3 {
+  color: #00f0f0;
+  font-size: 12px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.class-241-1, .class-241-2, .class-241-3, .class-241-4 {
+  color: #00f1f1;
+  font-size: 13px;
+  margin: 1px;
+  padding: 1px;
+}
+
+.class-242-1, .class-242-2, .class-242-3, .class-242-4, .class-242-5 {
+  color: #00f2f2;
+  font-size: 14px;
+  margin: 2px;
+  padding: 2px;
+}
+
+.class-243-1, .class-243-2, .class-243-3 {
+  color: #00f3f3;
+  font-size: 15px;
+  margin: 3px;
+  padding: 3px;
+}
+
+.class-244-1, .class-244-2, .class-244-3, .class-244-4 {
+  color: #00f4f4;
+  font-size: 16px;
+  margin: 4px;
+  padding: 4px;
+}
+
+.class-245-1, .class-245-2, .class-245-3, .class-245-4, .class-245-5 {
+  color: #00f5f5;
+  font-size: 17px;
+  margin: 5px;
+  padding: 5px;
+}
+
+.class-246-1, .class-246-2, .class-246-3 {
+  color: #00f6f6;
+  font-size: 18px;
+  margin: 6px;
+  padding: 6px;
+}
+
+.class-247-1, .class-247-2, .class-247-3, .class-247-4 {
+  color: #00f7f7;
+  font-size: 19px;
+  margin: 7px;
+  padding: 7px;
+}
+
+.class-248-1, .class-248-2, .class-248-3, .class-248-4, .class-248-5 {
+  color: #00f8f8;
+  font-size: 12px;
+  margin: 8px;
+  padding: 8px;
+}
+
+.class-249-1, .class-249-2, .class-249-3 {
+  color: #00f9f9;
+  font-size: 13px;
+  margin: 9px;
+  padding: 9px;
+}
+
+.class-250-1, .class-250-2, .class-250-3, .class-250-4 {
+  color: #00fafa;
+  font-size: 14px;
+  margin: 10px;
+  padding: 10px;
+}
+
+.class-251-1, .class-251-2, .class-251-3, .class-251-4, .class-251-5 {
+  color: #00fbfb;
+  font-size: 15px;
+  margin: 11px;
+  padding: 11px;
+}
+
+.class-252-1, .class-252-2, .class-252-3 {
+  color: #00fcfc;
+  font-size: 16px;
+  margin: 12px;
+  padding: 12px;
+}
+
+.class-253-1, .class-253-2, .class-253-3, .class-253-4 {
+  color: #00fdfd;
+  font-size: 17px;
+  margin: 13px;
+  padding: 13px;
+}
+
+.class-254-1, .class-254-2, .class-254-3, .class-254-4, .class-254-5 {
+  color: #00fefe;
+  font-size: 18px;
+  margin: 14px;
+  padding: 14px;
+}
+
+.class-255-1, .class-255-2, .class-255-3 {
+  color: #00ffff;
+  font-size: 19px;
+  margin: 15px;
+  padding: 0px;
+}
+
+.class-256-1, .class-256-2, .class-256-3, .class-256-4 {
+  color: #010100;
+  font-size: 12px;
+  margin: 16px;
+  padding: 1px;
+}
+
+.class-257-1, .class-257-2, .class-257-3, .class-257-4, .class-257-5 {
+  color: #010201;
+  font-size: 13px;
+  margin: 17px;
+  padding: 2px;
+}
+
+.class-258-1, .class-258-2, .class-258-3 {
+  color: #010302;
+  font-size: 14px;
+  margin: 18px;
+  padding: 3px;
+}
+
+.class-259-1, .class-259-2, .class-259-3, .class-259-4 {
+  color: #010403;
+  font-size: 15px;
+  margin: 19px;
+  padding: 4px;
+}
+
+.class-260-1, .class-260-2, .class-260-3, .class-260-4, .class-260-5 {
+  color: #010504;
+  font-size: 16px;
+  margin: 0px;
+  padding: 5px;
+}
+
+.class-261-1, .class-261-2, .class-261-3 {
+  color: #010605;
+  font-size: 17px;
+  margin: 1px;
+  padding: 6px;
+}
+
+.class-262-1, .class-262-2, .class-262-3, .class-262-4 {
+  color: #010706;
+  font-size: 18px;
+  margin: 2px;
+  padding: 7px;
+}
+
+.class-263-1, .class-263-2, .class-263-3, .class-263-4, .class-263-5 {
+  color: #010807;
+  font-size: 19px;
+  margin: 3px;
+  padding: 8px;
+}
+
+.class-264-1, .class-264-2, .class-264-3 {
+  color: #010908;
+  font-size: 12px;
+  margin: 4px;
+  padding: 9px;
+}
+
+.class-265-1, .class-265-2, .class-265-3, .class-265-4 {
+  color: #010a09;
+  font-size: 13px;
+  margin: 5px;
+  padding: 10px;
+}
+
+.class-266-1, .class-266-2, .class-266-3, .class-266-4, .class-266-5 {
+  color: #010b0a;
+  font-size: 14px;
+  margin: 6px;
+  padding: 11px;
+}
+
+.class-267-1, .class-267-2, .class-267-3 {
+  color: #010c0b;
+  font-size: 15px;
+  margin: 7px;
+  padding: 12px;
+}
+
+.class-268-1, .class-268-2, .class-268-3, .class-268-4 {
+  color: #010d0c;
+  font-size: 16px;
+  margin: 8px;
+  padding: 13px;
+}
+
+.class-269-1, .class-269-2, .class-269-3, .class-269-4, .class-269-5 {
+  color: #010e0d;
+  font-size: 17px;
+  margin: 9px;
+  padding: 14px;
+}
+
+.class-270-1, .class-270-2, .class-270-3 {
+  color: #010f0e;
+  font-size: 18px;
+  margin: 10px;
+  padding: 0px;
+}
+
+.class-271-1, .class-271-2, .class-271-3, .class-271-4 {
+  color: #01100f;
+  font-size: 19px;
+  margin: 11px;
+  padding: 1px;
+}
+
+.class-272-1, .class-272-2, .class-272-3, .class-272-4, .class-272-5 {
+  color: #011110;
+  font-size: 12px;
+  margin: 12px;
+  padding: 2px;
+}
+
+.class-273-1, .class-273-2, .class-273-3 {
+  color: #011211;
+  font-size: 13px;
+  margin: 13px;
+  padding: 3px;
+}
+
+.class-274-1, .class-274-2, .class-274-3, .class-274-4 {
+  color: #011312;
+  font-size: 14px;
+  margin: 14px;
+  padding: 4px;
+}
+
+.class-275-1, .class-275-2, .class-275-3, .class-275-4, .class-275-5 {
+  color: #011413;
+  font-size: 15px;
+  margin: 15px;
+  padding: 5px;
+}
+
+.class-276-1, .class-276-2, .class-276-3 {
+  color: #011514;
+  font-size: 16px;
+  margin: 16px;
+  padding: 6px;
+}
+
+.class-277-1, .class-277-2, .class-277-3, .class-277-4 {
+  color: #011615;
+  font-size: 17px;
+  margin: 17px;
+  padding: 7px;
+}
+
+.class-278-1, .class-278-2, .class-278-3, .class-278-4, .class-278-5 {
+  color: #011716;
+  font-size: 18px;
+  margin: 18px;
+  padding: 8px;
+}
+
+.class-279-1, .class-279-2, .class-279-3 {
+  color: #011817;
+  font-size: 19px;
+  margin: 19px;
+  padding: 9px;
+}
+
+.class-280-1, .class-280-2, .class-280-3, .class-280-4 {
+  color: #011918;
+  font-size: 12px;
+  margin: 0px;
+  padding: 10px;
+}
+
+.class-281-1, .class-281-2, .class-281-3, .class-281-4, .class-281-5 {
+  color: #011a19;
+  font-size: 13px;
+  margin: 1px;
+  padding: 11px;
+}
+
+.class-282-1, .class-282-2, .class-282-3 {
+  color: #011b1a;
+  font-size: 14px;
+  margin: 2px;
+  padding: 12px;
+}
+
+.class-283-1, .class-283-2, .class-283-3, .class-283-4 {
+  color: #011c1b;
+  font-size: 15px;
+  margin: 3px;
+  padding: 13px;
+}
+
+.class-284-1, .class-284-2, .class-284-3, .class-284-4, .class-284-5 {
+  color: #011d1c;
+  font-size: 16px;
+  margin: 4px;
+  padding: 14px;
+}
+
+.class-285-1, .class-285-2, .class-285-3 {
+  color: #011e1d;
+  font-size: 17px;
+  margin: 5px;
+  padding: 0px;
+}
+
+.class-286-1, .class-286-2, .class-286-3, .class-286-4 {
+  color: #011f1e;
+  font-size: 18px;
+  margin: 6px;
+  padding: 1px;
+}
+
+.class-287-1, .class-287-2, .class-287-3, .class-287-4, .class-287-5 {
+  color: #01201f;
+  font-size: 19px;
+  margin: 7px;
+  padding: 2px;
+}
+
+.class-288-1, .class-288-2, .class-288-3 {
+  color: #012120;
+  font-size: 12px;
+  margin: 8px;
+  padding: 3px;
+}
+
+.class-289-1, .class-289-2, .class-289-3, .class-289-4 {
+  color: #012221;
+  font-size: 13px;
+  margin: 9px;
+  padding: 4px;
+}
+
+.class-290-1, .class-290-2, .class-290-3, .class-290-4, .class-290-5 {
+  color: #012322;
+  font-size: 14px;
+  margin: 10px;
+  padding: 5px;
+}
+
+.class-291-1, .class-291-2, .class-291-3 {
+  color: #012423;
+  font-size: 15px;
+  margin: 11px;
+  padding: 6px;
+}
+
+.class-292-1, .class-292-2, .class-292-3, .class-292-4 {
+  color: #012524;
+  font-size: 16px;
+  margin: 12px;
+  padding: 7px;
+}
+
+.class-293-1, .class-293-2, .class-293-3, .class-293-4, .class-293-5 {
+  color: #012625;
+  font-size: 17px;
+  margin: 13px;
+  padding: 8px;
+}
+
+.class-294-1, .class-294-2, .class-294-3 {
+  color: #012726;
+  font-size: 18px;
+  margin: 14px;
+  padding: 9px;
+}
+
+.class-295-1, .class-295-2, .class-295-3, .class-295-4 {
+  color: #012827;
+  font-size: 19px;
+  margin: 15px;
+  padding: 10px;
+}
+
+.class-296-1, .class-296-2, .class-296-3, .class-296-4, .class-296-5 {
+  color: #012928;
+  font-size: 12px;
+  margin: 16px;
+  padding: 11px;
+}
+
+.class-297-1, .class-297-2, .class-297-3 {
+  color: #012a29;
+  font-size: 13px;
+  margin: 17px;
+  padding: 12px;
+}
+
+.class-298-1, .class-298-2, .class-298-3, .class-298-4 {
+  color: #012b2a;
+  font-size: 14px;
+  margin: 18px;
+  padding: 13px;
+}
+
+.class-299-1, .class-299-2, .class-299-3, .class-299-4, .class-299-5 {
+  color: #012c2b;
+  font-size: 15px;
+  margin: 19px;
+  padding: 14px;
+}
+
+.class-300-1, .class-300-2, .class-300-3 {
+  color: #012d2c;
+  font-size: 16px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.class-301-1, .class-301-2, .class-301-3, .class-301-4 {
+  color: #012e2d;
+  font-size: 17px;
+  margin: 1px;
+  padding: 1px;
+}
+
+.class-302-1, .class-302-2, .class-302-3, .class-302-4, .class-302-5 {
+  color: #012f2e;
+  font-size: 18px;
+  margin: 2px;
+  padding: 2px;
+}
+
+.class-303-1, .class-303-2, .class-303-3 {
+  color: #01302f;
+  font-size: 19px;
+  margin: 3px;
+  padding: 3px;
+}
+
+.class-304-1, .class-304-2, .class-304-3, .class-304-4 {
+  color: #013130;
+  font-size: 12px;
+  margin: 4px;
+  padding: 4px;
+}
+
+.class-305-1, .class-305-2, .class-305-3, .class-305-4, .class-305-5 {
+  color: #013231;
+  font-size: 13px;
+  margin: 5px;
+  padding: 5px;
+}
+
+.class-306-1, .class-306-2, .class-306-3 {
+  color: #013332;
+  font-size: 14px;
+  margin: 6px;
+  padding: 6px;
+}
+
+.class-307-1, .class-307-2, .class-307-3, .class-307-4 {
+  color: #013433;
+  font-size: 15px;
+  margin: 7px;
+  padding: 7px;
+}
+
+.class-308-1, .class-308-2, .class-308-3, .class-308-4, .class-308-5 {
+  color: #013534;
+  font-size: 16px;
+  margin: 8px;
+  padding: 8px;
+}
+
+.class-309-1, .class-309-2, .class-309-3 {
+  color: #013635;
+  font-size: 17px;
+  margin: 9px;
+  padding: 9px;
+}
+
+.class-310-1, .class-310-2, .class-310-3, .class-310-4 {
+  color: #013736;
+  font-size: 18px;
+  margin: 10px;
+  padding: 10px;
+}
+
+.class-311-1, .class-311-2, .class-311-3, .class-311-4, .class-311-5 {
+  color: #013837;
+  font-size: 19px;
+  margin: 11px;
+  padding: 11px;
+}
+
+.class-312-1, .class-312-2, .class-312-3 {
+  color: #013938;
+  font-size: 12px;
+  margin: 12px;
+  padding: 12px;
+}
+
+.class-313-1, .class-313-2, .class-313-3, .class-313-4 {
+  color: #013a39;
+  font-size: 13px;
+  margin: 13px;
+  padding: 13px;
+}
+
+.class-314-1, .class-314-2, .class-314-3, .class-314-4, .class-314-5 {
+  color: #013b3a;
+  font-size: 14px;
+  margin: 14px;
+  padding: 14px;
+}
+
+.class-315-1, .class-315-2, .class-315-3 {
+  color: #013c3b;
+  font-size: 15px;
+  margin: 15px;
+  padding: 0px;
+}
+
+.class-316-1, .class-316-2, .class-316-3, .class-316-4 {
+  color: #013d3c;
+  font-size: 16px;
+  margin: 16px;
+  padding: 1px;
+}
+
+.class-317-1, .class-317-2, .class-317-3, .class-317-4, .class-317-5 {
+  color: #013e3d;
+  font-size: 17px;
+  margin: 17px;
+  padding: 2px;
+}
+
+.class-318-1, .class-318-2, .class-318-3 {
+  color: #013f3e;
+  font-size: 18px;
+  margin: 18px;
+  padding: 3px;
+}
+
+.class-319-1, .class-319-2, .class-319-3, .class-319-4 {
+  color: #01403f;
+  font-size: 19px;
+  margin: 19px;
+  padding: 4px;
+}
+
+.class-320-1, .class-320-2, .class-320-3, .class-320-4, .class-320-5 {
+  color: #014140;
+  font-size: 12px;
+  margin: 0px;
+  padding: 5px;
+}
+
+.class-321-1, .class-321-2, .class-321-3 {
+  color: #014241;
+  font-size: 13px;
+  margin: 1px;
+  padding: 6px;
+}
+
+.class-322-1, .class-322-2, .class-322-3, .class-322-4 {
+  color: #014342;
+  font-size: 14px;
+  margin: 2px;
+  padding: 7px;
+}
+
+.class-323-1, .class-323-2, .class-323-3, .class-323-4, .class-323-5 {
+  color: #014443;
+  font-size: 15px;
+  margin: 3px;
+  padding: 8px;
+}
+
+.class-324-1, .class-324-2, .class-324-3 {
+  color: #014544;
+  font-size: 16px;
+  margin: 4px;
+  padding: 9px;
+}
+
+.class-325-1, .class-325-2, .class-325-3, .class-325-4 {
+  color: #014645;
+  font-size: 17px;
+  margin: 5px;
+  padding: 10px;
+}
+
+.class-326-1, .class-326-2, .class-326-3, .class-326-4, .class-326-5 {
+  color: #014746;
+  font-size: 18px;
+  margin: 6px;
+  padding: 11px;
+}
+
+.class-327-1, .class-327-2, .class-327-3 {
+  color: #014847;
+  font-size: 19px;
+  margin: 7px;
+  padding: 12px;
+}
+
+.class-328-1, .class-328-2, .class-328-3, .class-328-4 {
+  color: #014948;
+  font-size: 12px;
+  margin: 8px;
+  padding: 13px;
+}
+
+.class-329-1, .class-329-2, .class-329-3, .class-329-4, .class-329-5 {
+  color: #014a49;
+  font-size: 13px;
+  margin: 9px;
+  padding: 14px;
+}
+
+.class-330-1, .class-330-2, .class-330-3 {
+  color: #014b4a;
+  font-size: 14px;
+  margin: 10px;
+  padding: 0px;
+}
+
+.class-331-1, .class-331-2, .class-331-3, .class-331-4 {
+  color: #014c4b;
+  font-size: 15px;
+  margin: 11px;
+  padding: 1px;
+}
+
+.class-332-1, .class-332-2, .class-332-3, .class-332-4, .class-332-5 {
+  color: #014d4c;
+  font-size: 16px;
+  margin: 12px;
+  padding: 2px;
+}
+
+.class-333-1, .class-333-2, .class-333-3 {
+  color: #014e4d;
+  font-size: 17px;
+  margin: 13px;
+  padding: 3px;
+}
+
+.class-334-1, .class-334-2, .class-334-3, .class-334-4 {
+  color: #014f4e;
+  font-size: 18px;
+  margin: 14px;
+  padding: 4px;
+}
+
+.class-335-1, .class-335-2, .class-335-3, .class-335-4, .class-335-5 {
+  color: #01504f;
+  font-size: 19px;
+  margin: 15px;
+  padding: 5px;
+}
+
+.class-336-1, .class-336-2, .class-336-3 {
+  color: #015150;
+  font-size: 12px;
+  margin: 16px;
+  padding: 6px;
+}
+
+.class-337-1, .class-337-2, .class-337-3, .class-337-4 {
+  color: #015251;
+  font-size: 13px;
+  margin: 17px;
+  padding: 7px;
+}
+
+.class-338-1, .class-338-2, .class-338-3, .class-338-4, .class-338-5 {
+  color: #015352;
+  font-size: 14px;
+  margin: 18px;
+  padding: 8px;
+}
+
+.class-339-1, .class-339-2, .class-339-3 {
+  color: #015453;
+  font-size: 15px;
+  margin: 19px;
+  padding: 9px;
+}
+
+.class-340-1, .class-340-2, .class-340-3, .class-340-4 {
+  color: #015554;
+  font-size: 16px;
+  margin: 0px;
+  padding: 10px;
+}
+
+.class-341-1, .class-341-2, .class-341-3, .class-341-4, .class-341-5 {
+  color: #015655;
+  font-size: 17px;
+  margin: 1px;
+  padding: 11px;
+}
+
+.class-342-1, .class-342-2, .class-342-3 {
+  color: #015756;
+  font-size: 18px;
+  margin: 2px;
+  padding: 12px;
+}
+
+.class-343-1, .class-343-2, .class-343-3, .class-343-4 {
+  color: #015857;
+  font-size: 19px;
+  margin: 3px;
+  padding: 13px;
+}
+
+.class-344-1, .class-344-2, .class-344-3, .class-344-4, .class-344-5 {
+  color: #015958;
+  font-size: 12px;
+  margin: 4px;
+  padding: 14px;
+}
+
+.class-345-1, .class-345-2, .class-345-3 {
+  color: #015a59;
+  font-size: 13px;
+  margin: 5px;
+  padding: 0px;
+}
+
+.class-346-1, .class-346-2, .class-346-3, .class-346-4 {
+  color: #015b5a;
+  font-size: 14px;
+  margin: 6px;
+  padding: 1px;
+}
+
+.class-347-1, .class-347-2, .class-347-3, .class-347-4, .class-347-5 {
+  color: #015c5b;
+  font-size: 15px;
+  margin: 7px;
+  padding: 2px;
+}
+
+.class-348-1, .class-348-2, .class-348-3 {
+  color: #015d5c;
+  font-size: 16px;
+  margin: 8px;
+  padding: 3px;
+}
+
+.class-349-1, .class-349-2, .class-349-3, .class-349-4 {
+  color: #015e5d;
+  font-size: 17px;
+  margin: 9px;
+  padding: 4px;
+}
+
+.class-350-1, .class-350-2, .class-350-3, .class-350-4, .class-350-5 {
+  color: #015f5e;
+  font-size: 18px;
+  margin: 10px;
+  padding: 5px;
+}
+
+.class-351-1, .class-351-2, .class-351-3 {
+  color: #01605f;
+  font-size: 19px;
+  margin: 11px;
+  padding: 6px;
+}
+
+.class-352-1, .class-352-2, .class-352-3, .class-352-4 {
+  color: #016160;
+  font-size: 12px;
+  margin: 12px;
+  padding: 7px;
+}
+
+.class-353-1, .class-353-2, .class-353-3, .class-353-4, .class-353-5 {
+  color: #016261;
+  font-size: 13px;
+  margin: 13px;
+  padding: 8px;
+}
+
+.class-354-1, .class-354-2, .class-354-3 {
+  color: #016362;
+  font-size: 14px;
+  margin: 14px;
+  padding: 9px;
+}
+
+.class-355-1, .class-355-2, .class-355-3, .class-355-4 {
+  color: #016463;
+  font-size: 15px;
+  margin: 15px;
+  padding: 10px;
+}
+
+.class-356-1, .class-356-2, .class-356-3, .class-356-4, .class-356-5 {
+  color: #016564;
+  font-size: 16px;
+  margin: 16px;
+  padding: 11px;
+}
+
+.class-357-1, .class-357-2, .class-357-3 {
+  color: #016665;
+  font-size: 17px;
+  margin: 17px;
+  padding: 12px;
+}
+
+.class-358-1, .class-358-2, .class-358-3, .class-358-4 {
+  color: #016766;
+  font-size: 18px;
+  margin: 18px;
+  padding: 13px;
+}
+
+.class-359-1, .class-359-2, .class-359-3, .class-359-4, .class-359-5 {
+  color: #016867;
+  font-size: 19px;
+  margin: 19px;
+  padding: 14px;
+}
+
+.class-360-1, .class-360-2, .class-360-3 {
+  color: #016968;
+  font-size: 12px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.class-361-1, .class-361-2, .class-361-3, .class-361-4 {
+  color: #016a69;
+  font-size: 13px;
+  margin: 1px;
+  padding: 1px;
+}
+
+.class-362-1, .class-362-2, .class-362-3, .class-362-4, .class-362-5 {
+  color: #016b6a;
+  font-size: 14px;
+  margin: 2px;
+  padding: 2px;
+}
+
+.class-363-1, .class-363-2, .class-363-3 {
+  color: #016c6b;
+  font-size: 15px;
+  margin: 3px;
+  padding: 3px;
+}
+
+.class-364-1, .class-364-2, .class-364-3, .class-364-4 {
+  color: #016d6c;
+  font-size: 16px;
+  margin: 4px;
+  padding: 4px;
+}
+
+.class-365-1, .class-365-2, .class-365-3, .class-365-4, .class-365-5 {
+  color: #016e6d;
+  font-size: 17px;
+  margin: 5px;
+  padding: 5px;
+}
+
+.class-366-1, .class-366-2, .class-366-3 {
+  color: #016f6e;
+  font-size: 18px;
+  margin: 6px;
+  padding: 6px;
+}
+
+.class-367-1, .class-367-2, .class-367-3, .class-367-4 {
+  color: #01706f;
+  font-size: 19px;
+  margin: 7px;
+  padding: 7px;
+}
+
+.class-368-1, .class-368-2, .class-368-3, .class-368-4, .class-368-5 {
+  color: #017170;
+  font-size: 12px;
+  margin: 8px;
+  padding: 8px;
+}
+
+.class-369-1, .class-369-2, .class-369-3 {
+  color: #017271;
+  font-size: 13px;
+  margin: 9px;
+  padding: 9px;
+}
+
+.class-370-1, .class-370-2, .class-370-3, .class-370-4 {
+  color: #017372;
+  font-size: 14px;
+  margin: 10px;
+  padding: 10px;
+}
+
+.class-371-1, .class-371-2, .class-371-3, .class-371-4, .class-371-5 {
+  color: #017473;
+  font-size: 15px;
+  margin: 11px;
+  padding: 11px;
+}
+
+.class-372-1, .class-372-2, .class-372-3 {
+  color: #017574;
+  font-size: 16px;
+  margin: 12px;
+  padding: 12px;
+}
+
+.class-373-1, .class-373-2, .class-373-3, .class-373-4 {
+  color: #017675;
+  font-size: 17px;
+  margin: 13px;
+  padding: 13px;
+}
+
+.class-374-1, .class-374-2, .class-374-3, .class-374-4, .class-374-5 {
+  color: #017776;
+  font-size: 18px;
+  margin: 14px;
+  padding: 14px;
+}
+
+.class-375-1, .class-375-2, .class-375-3 {
+  color: #017877;
+  font-size: 19px;
+  margin: 15px;
+  padding: 0px;
+}
+
+.class-376-1, .class-376-2, .class-376-3, .class-376-4 {
+  color: #017978;
+  font-size: 12px;
+  margin: 16px;
+  padding: 1px;
+}
+
+.class-377-1, .class-377-2, .class-377-3, .class-377-4, .class-377-5 {
+  color: #017a79;
+  font-size: 13px;
+  margin: 17px;
+  padding: 2px;
+}
+
+.class-378-1, .class-378-2, .class-378-3 {
+  color: #017b7a;
+  font-size: 14px;
+  margin: 18px;
+  padding: 3px;
+}
+
+.class-379-1, .class-379-2, .class-379-3, .class-379-4 {
+  color: #017c7b;
+  font-size: 15px;
+  margin: 19px;
+  padding: 4px;
+}
+
+.class-380-1, .class-380-2, .class-380-3, .class-380-4, .class-380-5 {
+  color: #017d7c;
+  font-size: 16px;
+  margin: 0px;
+  padding: 5px;
+}
+
+.class-381-1, .class-381-2, .class-381-3 {
+  color: #017e7d;
+  font-size: 17px;
+  margin: 1px;
+  padding: 6px;
+}
+
+.class-382-1, .class-382-2, .class-382-3, .class-382-4 {
+  color: #017f7e;
+  font-size: 18px;
+  margin: 2px;
+  padding: 7px;
+}
+
+.class-383-1, .class-383-2, .class-383-3, .class-383-4, .class-383-5 {
+  color: #01807f;
+  font-size: 19px;
+  margin: 3px;
+  padding: 8px;
+}
+
+.class-384-1, .class-384-2, .class-384-3 {
+  color: #018180;
+  font-size: 12px;
+  margin: 4px;
+  padding: 9px;
+}
+
+.class-385-1, .class-385-2, .class-385-3, .class-385-4 {
+  color: #018281;
+  font-size: 13px;
+  margin: 5px;
+  padding: 10px;
+}
+
+.class-386-1, .class-386-2, .class-386-3, .class-386-4, .class-386-5 {
+  color: #018382;
+  font-size: 14px;
+  margin: 6px;
+  padding: 11px;
+}
+
+.class-387-1, .class-387-2, .class-387-3 {
+  color: #018483;
+  font-size: 15px;
+  margin: 7px;
+  padding: 12px;
+}
+
+.class-388-1, .class-388-2, .class-388-3, .class-388-4 {
+  color: #018584;
+  font-size: 16px;
+  margin: 8px;
+  padding: 13px;
+}
+
+.class-389-1, .class-389-2, .class-389-3, .class-389-4, .class-389-5 {
+  color: #018685;
+  font-size: 17px;
+  margin: 9px;
+  padding: 14px;
+}
+
+.class-390-1, .class-390-2, .class-390-3 {
+  color: #018786;
+  font-size: 18px;
+  margin: 10px;
+  padding: 0px;
+}
+
+.class-391-1, .class-391-2, .class-391-3, .class-391-4 {
+  color: #018887;
+  font-size: 19px;
+  margin: 11px;
+  padding: 1px;
+}
+
+.class-392-1, .class-392-2, .class-392-3, .class-392-4, .class-392-5 {
+  color: #018988;
+  font-size: 12px;
+  margin: 12px;
+  padding: 2px;
+}
+
+.class-393-1, .class-393-2, .class-393-3 {
+  color: #018a89;
+  font-size: 13px;
+  margin: 13px;
+  padding: 3px;
+}
+
+.class-394-1, .class-394-2, .class-394-3, .class-394-4 {
+  color: #018b8a;
+  font-size: 14px;
+  margin: 14px;
+  padding: 4px;
+}
+
+.class-395-1, .class-395-2, .class-395-3, .class-395-4, .class-395-5 {
+  color: #018c8b;
+  font-size: 15px;
+  margin: 15px;
+  padding: 5px;
+}
+
+.class-396-1, .class-396-2, .class-396-3 {
+  color: #018d8c;
+  font-size: 16px;
+  margin: 16px;
+  padding: 6px;
+}
+
+.class-397-1, .class-397-2, .class-397-3, .class-397-4 {
+  color: #018e8d;
+  font-size: 17px;
+  margin: 17px;
+  padding: 7px;
+}
+
+.class-398-1, .class-398-2, .class-398-3, .class-398-4, .class-398-5 {
+  color: #018f8e;
+  font-size: 18px;
+  margin: 18px;
+  padding: 8px;
+}
+
+.class-399-1, .class-399-2, .class-399-3 {
+  color: #01908f;
+  font-size: 19px;
+  margin: 19px;
+  padding: 9px;
+}
+
+.class-400-1, .class-400-2, .class-400-3, .class-400-4 {
+  color: #019190;
+  font-size: 12px;
+  margin: 0px;
+  padding: 10px;
+}
+
+.class-401-1, .class-401-2, .class-401-3, .class-401-4, .class-401-5 {
+  color: #019291;
+  font-size: 13px;
+  margin: 1px;
+  padding: 11px;
+}
+
+.class-402-1, .class-402-2, .class-402-3 {
+  color: #019392;
+  font-size: 14px;
+  margin: 2px;
+  padding: 12px;
+}
+
+.class-403-1, .class-403-2, .class-403-3, .class-403-4 {
+  color: #019493;
+  font-size: 15px;
+  margin: 3px;
+  padding: 13px;
+}
+
+.class-404-1, .class-404-2, .class-404-3, .class-404-4, .class-404-5 {
+  color: #019594;
+  font-size: 16px;
+  margin: 4px;
+  padding: 14px;
+}
+
+.class-405-1, .class-405-2, .class-405-3 {
+  color: #019695;
+  font-size: 17px;
+  margin: 5px;
+  padding: 0px;
+}
+
+.class-406-1, .class-406-2, .class-406-3, .class-406-4 {
+  color: #019796;
+  font-size: 18px;
+  margin: 6px;
+  padding: 1px;
+}
+
+.class-407-1, .class-407-2, .class-407-3, .class-407-4, .class-407-5 {
+  color: #019897;
+  font-size: 19px;
+  margin: 7px;
+  padding: 2px;
+}
+
+.class-408-1, .class-408-2, .class-408-3 {
+  color: #019998;
+  font-size: 12px;
+  margin: 8px;
+  padding: 3px;
+}
+
+.class-409-1, .class-409-2, .class-409-3, .class-409-4 {
+  color: #019a99;
+  font-size: 13px;
+  margin: 9px;
+  padding: 4px;
+}
+
+.class-410-1, .class-410-2, .class-410-3, .class-410-4, .class-410-5 {
+  color: #019b9a;
+  font-size: 14px;
+  margin: 10px;
+  padding: 5px;
+}
+
+.class-411-1, .class-411-2, .class-411-3 {
+  color: #019c9b;
+  font-size: 15px;
+  margin: 11px;
+  padding: 6px;
+}
+
+.class-412-1, .class-412-2, .class-412-3, .class-412-4 {
+  color: #019d9c;
+  font-size: 16px;
+  margin: 12px;
+  padding: 7px;
+}
+
+.class-413-1, .class-413-2, .class-413-3, .class-413-4, .class-413-5 {
+  color: #019e9d;
+  font-size: 17px;
+  margin: 13px;
+  padding: 8px;
+}
+
+.class-414-1, .class-414-2, .class-414-3 {
+  color: #019f9e;
+  font-size: 18px;
+  margin: 14px;
+  padding: 9px;
+}
+
+.class-415-1, .class-415-2, .class-415-3, .class-415-4 {
+  color: #01a09f;
+  font-size: 19px;
+  margin: 15px;
+  padding: 10px;
+}
+
+.class-416-1, .class-416-2, .class-416-3, .class-416-4, .class-416-5 {
+  color: #01a1a0;
+  font-size: 12px;
+  margin: 16px;
+  padding: 11px;
+}
+
+.class-417-1, .class-417-2, .class-417-3 {
+  color: #01a2a1;
+  font-size: 13px;
+  margin: 17px;
+  padding: 12px;
+}
+
+.class-418-1, .class-418-2, .class-418-3, .class-418-4 {
+  color: #01a3a2;
+  font-size: 14px;
+  margin: 18px;
+  padding: 13px;
+}
+
+.class-419-1, .class-419-2, .class-419-3, .class-419-4, .class-419-5 {
+  color: #01a4a3;
+  font-size: 15px;
+  margin: 19px;
+  padding: 14px;
+}
+
+.class-420-1, .class-420-2, .class-420-3 {
+  color: #01a5a4;
+  font-size: 16px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.class-421-1, .class-421-2, .class-421-3, .class-421-4 {
+  color: #01a6a5;
+  font-size: 17px;
+  margin: 1px;
+  padding: 1px;
+}
+
+.class-422-1, .class-422-2, .class-422-3, .class-422-4, .class-422-5 {
+  color: #01a7a6;
+  font-size: 18px;
+  margin: 2px;
+  padding: 2px;
+}
+
+.class-423-1, .class-423-2, .class-423-3 {
+  color: #01a8a7;
+  font-size: 19px;
+  margin: 3px;
+  padding: 3px;
+}
+
+.class-424-1, .class-424-2, .class-424-3, .class-424-4 {
+  color: #01a9a8;
+  font-size: 12px;
+  margin: 4px;
+  padding: 4px;
+}
+
+.class-425-1, .class-425-2, .class-425-3, .class-425-4, .class-425-5 {
+  color: #01aaa9;
+  font-size: 13px;
+  margin: 5px;
+  padding: 5px;
+}
+
+.class-426-1, .class-426-2, .class-426-3 {
+  color: #01abaa;
+  font-size: 14px;
+  margin: 6px;
+  padding: 6px;
+}
+
+.class-427-1, .class-427-2, .class-427-3, .class-427-4 {
+  color: #01acab;
+  font-size: 15px;
+  margin: 7px;
+  padding: 7px;
+}
+
+.class-428-1, .class-428-2, .class-428-3, .class-428-4, .class-428-5 {
+  color: #01adac;
+  font-size: 16px;
+  margin: 8px;
+  padding: 8px;
+}
+
+.class-429-1, .class-429-2, .class-429-3 {
+  color: #01aead;
+  font-size: 17px;
+  margin: 9px;
+  padding: 9px;
+}
+
+.class-430-1, .class-430-2, .class-430-3, .class-430-4 {
+  color: #01afae;
+  font-size: 18px;
+  margin: 10px;
+  padding: 10px;
+}
+
+.class-431-1, .class-431-2, .class-431-3, .class-431-4, .class-431-5 {
+  color: #01b0af;
+  font-size: 19px;
+  margin: 11px;
+  padding: 11px;
+}
+
+.class-432-1, .class-432-2, .class-432-3 {
+  color: #01b1b0;
+  font-size: 12px;
+  margin: 12px;
+  padding: 12px;
+}
+
+.class-433-1, .class-433-2, .class-433-3, .class-433-4 {
+  color: #01b2b1;
+  font-size: 13px;
+  margin: 13px;
+  padding: 13px;
+}
+
+.class-434-1, .class-434-2, .class-434-3, .class-434-4, .class-434-5 {
+  color: #01b3b2;
+  font-size: 14px;
+  margin: 14px;
+  padding: 14px;
+}
+
+.class-435-1, .class-435-2, .class-435-3 {
+  color: #01b4b3;
+  font-size: 15px;
+  margin: 15px;
+  padding: 0px;
+}
+
+.class-436-1, .class-436-2, .class-436-3, .class-436-4 {
+  color: #01b5b4;
+  font-size: 16px;
+  margin: 16px;
+  padding: 1px;
+}
+
+.class-437-1, .class-437-2, .class-437-3, .class-437-4, .class-437-5 {
+  color: #01b6b5;
+  font-size: 17px;
+  margin: 17px;
+  padding: 2px;
+}
+
+.class-438-1, .class-438-2, .class-438-3 {
+  color: #01b7b6;
+  font-size: 18px;
+  margin: 18px;
+  padding: 3px;
+}
+
+.class-439-1, .class-439-2, .class-439-3, .class-439-4 {
+  color: #01b8b7;
+  font-size: 19px;
+  margin: 19px;
+  padding: 4px;
+}
+
+.class-440-1, .class-440-2, .class-440-3, .class-440-4, .class-440-5 {
+  color: #01b9b8;
+  font-size: 12px;
+  margin: 0px;
+  padding: 5px;
+}
+
+.class-441-1, .class-441-2, .class-441-3 {
+  color: #01bab9;
+  font-size: 13px;
+  margin: 1px;
+  padding: 6px;
+}
+
+.class-442-1, .class-442-2, .class-442-3, .class-442-4 {
+  color: #01bbba;
+  font-size: 14px;
+  margin: 2px;
+  padding: 7px;
+}
+
+.class-443-1, .class-443-2, .class-443-3, .class-443-4, .class-443-5 {
+  color: #01bcbb;
+  font-size: 15px;
+  margin: 3px;
+  padding: 8px;
+}
+
+.class-444-1, .class-444-2, .class-444-3 {
+  color: #01bdbc;
+  font-size: 16px;
+  margin: 4px;
+  padding: 9px;
+}
+
+.class-445-1, .class-445-2, .class-445-3, .class-445-4 {
+  color: #01bebd;
+  font-size: 17px;
+  margin: 5px;
+  padding: 10px;
+}
+
+.class-446-1, .class-446-2, .class-446-3, .class-446-4, .class-446-5 {
+  color: #01bfbe;
+  font-size: 18px;
+  margin: 6px;
+  padding: 11px;
+}
+
+.class-447-1, .class-447-2, .class-447-3 {
+  color: #01c0bf;
+  font-size: 19px;
+  margin: 7px;
+  padding: 12px;
+}
+
+.class-448-1, .class-448-2, .class-448-3, .class-448-4 {
+  color: #01c1c0;
+  font-size: 12px;
+  margin: 8px;
+  padding: 13px;
+}
+
+.class-449-1, .class-449-2, .class-449-3, .class-449-4, .class-449-5 {
+  color: #01c2c1;
+  font-size: 13px;
+  margin: 9px;
+  padding: 14px;
+}
+
+.class-450-1, .class-450-2, .class-450-3 {
+  color: #01c3c2;
+  font-size: 14px;
+  margin: 10px;
+  padding: 0px;
+}
+
+.class-451-1, .class-451-2, .class-451-3, .class-451-4 {
+  color: #01c4c3;
+  font-size: 15px;
+  margin: 11px;
+  padding: 1px;
+}
+
+.class-452-1, .class-452-2, .class-452-3, .class-452-4, .class-452-5 {
+  color: #01c5c4;
+  font-size: 16px;
+  margin: 12px;
+  padding: 2px;
+}
+
+.class-453-1, .class-453-2, .class-453-3 {
+  color: #01c6c5;
+  font-size: 17px;
+  margin: 13px;
+  padding: 3px;
+}
+
+.class-454-1, .class-454-2, .class-454-3, .class-454-4 {
+  color: #01c7c6;
+  font-size: 18px;
+  margin: 14px;
+  padding: 4px;
+}
+
+.class-455-1, .class-455-2, .class-455-3, .class-455-4, .class-455-5 {
+  color: #01c8c7;
+  font-size: 19px;
+  margin: 15px;
+  padding: 5px;
+}
+
+.class-456-1, .class-456-2, .class-456-3 {
+  color: #01c9c8;
+  font-size: 12px;
+  margin: 16px;
+  padding: 6px;
+}
+
+.class-457-1, .class-457-2, .class-457-3, .class-457-4 {
+  color: #01cac9;
+  font-size: 13px;
+  margin: 17px;
+  padding: 7px;
+}
+
+.class-458-1, .class-458-2, .class-458-3, .class-458-4, .class-458-5 {
+  color: #01cbca;
+  font-size: 14px;
+  margin: 18px;
+  padding: 8px;
+}
+
+.class-459-1, .class-459-2, .class-459-3 {
+  color: #01cccb;
+  font-size: 15px;
+  margin: 19px;
+  padding: 9px;
+}
+
+.class-460-1, .class-460-2, .class-460-3, .class-460-4 {
+  color: #01cdcc;
+  font-size: 16px;
+  margin: 0px;
+  padding: 10px;
+}
+
+.class-461-1, .class-461-2, .class-461-3, .class-461-4, .class-461-5 {
+  color: #01cecd;
+  font-size: 17px;
+  margin: 1px;
+  padding: 11px;
+}
+
+.class-462-1, .class-462-2, .class-462-3 {
+  color: #01cfce;
+  font-size: 18px;
+  margin: 2px;
+  padding: 12px;
+}
+
+.class-463-1, .class-463-2, .class-463-3, .class-463-4 {
+  color: #01d0cf;
+  font-size: 19px;
+  margin: 3px;
+  padding: 13px;
+}
+
+.class-464-1, .class-464-2, .class-464-3, .class-464-4, .class-464-5 {
+  color: #01d1d0;
+  font-size: 12px;
+  margin: 4px;
+  padding: 14px;
+}
+
+.class-465-1, .class-465-2, .class-465-3 {
+  color: #01d2d1;
+  font-size: 13px;
+  margin: 5px;
+  padding: 0px;
+}
+
+.class-466-1, .class-466-2, .class-466-3, .class-466-4 {
+  color: #01d3d2;
+  font-size: 14px;
+  margin: 6px;
+  padding: 1px;
+}
+
+.class-467-1, .class-467-2, .class-467-3, .class-467-4, .class-467-5 {
+  color: #01d4d3;
+  font-size: 15px;
+  margin: 7px;
+  padding: 2px;
+}
+
+.class-468-1, .class-468-2, .class-468-3 {
+  color: #01d5d4;
+  font-size: 16px;
+  margin: 8px;
+  padding: 3px;
+}
+
+.class-469-1, .class-469-2, .class-469-3, .class-469-4 {
+  color: #01d6d5;
+  font-size: 17px;
+  margin: 9px;
+  padding: 4px;
+}
+
+.class-470-1, .class-470-2, .class-470-3, .class-470-4, .class-470-5 {
+  color: #01d7d6;
+  font-size: 18px;
+  margin: 10px;
+  padding: 5px;
+}
+
+.class-471-1, .class-471-2, .class-471-3 {
+  color: #01d8d7;
+  font-size: 19px;
+  margin: 11px;
+  padding: 6px;
+}
+
+.class-472-1, .class-472-2, .class-472-3, .class-472-4 {
+  color: #01d9d8;
+  font-size: 12px;
+  margin: 12px;
+  padding: 7px;
+}
+
+.class-473-1, .class-473-2, .class-473-3, .class-473-4, .class-473-5 {
+  color: #01dad9;
+  font-size: 13px;
+  margin: 13px;
+  padding: 8px;
+}
+
+.class-474-1, .class-474-2, .class-474-3 {
+  color: #01dbda;
+  font-size: 14px;
+  margin: 14px;
+  padding: 9px;
+}
+
+.class-475-1, .class-475-2, .class-475-3, .class-475-4 {
+  color: #01dcdb;
+  font-size: 15px;
+  margin: 15px;
+  padding: 10px;
+}
+
+.class-476-1, .class-476-2, .class-476-3, .class-476-4, .class-476-5 {
+  color: #01dddc;
+  font-size: 16px;
+  margin: 16px;
+  padding: 11px;
+}
+
+.class-477-1, .class-477-2, .class-477-3 {
+  color: #01dedd;
+  font-size: 17px;
+  margin: 17px;
+  padding: 12px;
+}
+
+.class-478-1, .class-478-2, .class-478-3, .class-478-4 {
+  color: #01dfde;
+  font-size: 18px;
+  margin: 18px;
+  padding: 13px;
+}
+
+.class-479-1, .class-479-2, .class-479-3, .class-479-4, .class-479-5 {
+  color: #01e0df;
+  font-size: 19px;
+  margin: 19px;
+  padding: 14px;
+}
+
+.class-480-1, .class-480-2, .class-480-3 {
+  color: #01e1e0;
+  font-size: 12px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.class-481-1, .class-481-2, .class-481-3, .class-481-4 {
+  color: #01e2e1;
+  font-size: 13px;
+  margin: 1px;
+  padding: 1px;
+}
+
+.class-482-1, .class-482-2, .class-482-3, .class-482-4, .class-482-5 {
+  color: #01e3e2;
+  font-size: 14px;
+  margin: 2px;
+  padding: 2px;
+}
+
+.class-483-1, .class-483-2, .class-483-3 {
+  color: #01e4e3;
+  font-size: 15px;
+  margin: 3px;
+  padding: 3px;
+}
+
+.class-484-1, .class-484-2, .class-484-3, .class-484-4 {
+  color: #01e5e4;
+  font-size: 16px;
+  margin: 4px;
+  padding: 4px;
+}
+
+.class-485-1, .class-485-2, .class-485-3, .class-485-4, .class-485-5 {
+  color: #01e6e5;
+  font-size: 17px;
+  margin: 5px;
+  padding: 5px;
+}
+
+.class-486-1, .class-486-2, .class-486-3 {
+  color: #01e7e6;
+  font-size: 18px;
+  margin: 6px;
+  padding: 6px;
+}
+
+.class-487-1, .class-487-2, .class-487-3, .class-487-4 {
+  color: #01e8e7;
+  font-size: 19px;
+  margin: 7px;
+  padding: 7px;
+}
+
+.class-488-1, .class-488-2, .class-488-3, .class-488-4, .class-488-5 {
+  color: #01e9e8;
+  font-size: 12px;
+  margin: 8px;
+  padding: 8px;
+}
+
+.class-489-1, .class-489-2, .class-489-3 {
+  color: #01eae9;
+  font-size: 13px;
+  margin: 9px;
+  padding: 9px;
+}
+
+.class-490-1, .class-490-2, .class-490-3, .class-490-4 {
+  color: #01ebea;
+  font-size: 14px;
+  margin: 10px;
+  padding: 10px;
+}
+
+.class-491-1, .class-491-2, .class-491-3, .class-491-4, .class-491-5 {
+  color: #01eceb;
+  font-size: 15px;
+  margin: 11px;
+  padding: 11px;
+}
+
+.class-492-1, .class-492-2, .class-492-3 {
+  color: #01edec;
+  font-size: 16px;
+  margin: 12px;
+  padding: 12px;
+}
+
+.class-493-1, .class-493-2, .class-493-3, .class-493-4 {
+  color: #01eeed;
+  font-size: 17px;
+  margin: 13px;
+  padding: 13px;
+}
+
+.class-494-1, .class-494-2, .class-494-3, .class-494-4, .class-494-5 {
+  color: #01efee;
+  font-size: 18px;
+  margin: 14px;
+  padding: 14px;
+}
+
+.class-495-1, .class-495-2, .class-495-3 {
+  color: #01f0ef;
+  font-size: 19px;
+  margin: 15px;
+  padding: 0px;
+}
+
+.class-496-1, .class-496-2, .class-496-3, .class-496-4 {
+  color: #01f1f0;
+  font-size: 12px;
+  margin: 16px;
+  padding: 1px;
+}
+
+.class-497-1, .class-497-2, .class-497-3, .class-497-4, .class-497-5 {
+  color: #01f2f1;
+  font-size: 13px;
+  margin: 17px;
+  padding: 2px;
+}
+
+.class-498-1, .class-498-2, .class-498-3 {
+  color: #01f3f2;
+  font-size: 14px;
+  margin: 18px;
+  padding: 3px;
+}
+
+.class-499-1, .class-499-2, .class-499-3, .class-499-4 {
+  color: #01f4f3;
+  font-size: 15px;
+  margin: 19px;
+  padding: 4px;
+}
+

--- a/benchmarks/flattening_tests.rb
+++ b/benchmarks/flattening_tests.rb
@@ -63,12 +63,6 @@ module FlatteningTests
 
   def sanity_checks
     case base_impl_type
-    when :css_parser
-      require 'css_parser'
-      # Basic sanity check for css_parser
-      parser = CssParser::Parser.new
-      parser.add_block!('.test { color: red; }')
-      raise 'css_parser sanity check failed' if parser.to_s.empty?
     when :pure, :native
       # Verify flattening works correctly with Cataract
       css = ".test { color: black; }\n.test { margin: 10px; }"
@@ -92,8 +86,6 @@ module FlatteningTests
 
   def implementation_label
     base_label = case base_impl_type
-                 when :css_parser
-                   'css_parser gem'
                  when :pure
                    'cataract pure'
                  when :native
@@ -121,19 +113,6 @@ module FlatteningTests
       x.config(time: 5, warmup: 2)
 
       case base_impl_type
-      when :css_parser
-        # css_parser gem
-        parser = CssParser::Parser.new
-        parser.add_block!(css)
-        rule_sets = []
-        parser.each_selector do |selector, declarations, _specificity|
-          rule_sets << CssParser::RuleSet.new(selectors: selector, block: declarations)
-        end
-
-        x.report("css_parser gem: #{key}") do
-          CssParser.merge(rule_sets)
-        end
-
       when :pure
         # Cataract pure Ruby
         cataract_rules = Cataract.parse_css(css)

--- a/benchmarks/parsing_tests.rb
+++ b/benchmarks/parsing_tests.rb
@@ -68,12 +68,6 @@ module ParsingTests
 
   def sanity_checks
     case base_impl_type
-    when :css_parser
-      require 'css_parser'
-      # Basic sanity check for css_parser
-      parser = CssParser::Parser.new(import: false, io_exceptions: false)
-      parser.add_block!(css1)
-      raise 'css_parser sanity check failed' if parser.to_s.empty?
     when :pure, :native
       # Verify fixtures parse correctly with Cataract
       parser = Cataract::Stylesheet.new
@@ -116,8 +110,6 @@ module ParsingTests
 
   def implementation_label
     base_label = case base_impl_type
-                 when :css_parser
-                   'css_parser gem'
                  when :pure
                    'cataract pure'
                  when :native
@@ -142,11 +134,6 @@ module ParsingTests
       x.config(time: 5, warmup: 2)
 
       case base_impl_type
-      when :css_parser
-        x.report('css_parser gem: small') do
-          parser = CssParser::Parser.new(import: false, io_exceptions: false)
-          parser.add_block!(css1)
-        end
       when :pure
         x.report('cataract pure: small') do
           parser = Cataract::Stylesheet.new
@@ -170,11 +157,6 @@ module ParsingTests
       x.config(time: 5, warmup: 2)
 
       case base_impl_type
-      when :css_parser
-        x.report('css_parser gem: medium with @media') do
-          parser = CssParser::Parser.new(import: false, io_exceptions: false)
-          parser.add_block!(css2)
-        end
       when :pure
         x.report('cataract pure: medium with @media') do
           parser = Cataract::Stylesheet.new
@@ -190,9 +172,6 @@ module ParsingTests
   end
 
   def run_selector_lists_benchmark
-    # Only test Cataract implementations (css_parser doesn't have this feature)
-    return if base_impl_type == :css_parser
-
     puts "\n#{'=' * 80}"
     puts "TEST: Selector lists (#{selector_lists_css.lines.count} lines, #{selector_lists_css.length} chars) - #{implementation_label}"
     puts '=' * 80

--- a/benchmarks/serialization_tests.rb
+++ b/benchmarks/serialization_tests.rb
@@ -15,22 +15,68 @@ module SerializationTests
         File.expand_path('../test/fixtures/bootstrap.css', __dir__)
       end
 
+      def compact_path
+        File.expand_path('../test/fixtures/serialization_compact.css', __dir__)
+      end
+
+      def nested_path
+        File.expand_path('../test/fixtures/serialization_nested.css', __dir__)
+      end
+
+      def selector_lists_path
+        File.expand_path('../test/fixtures/serialization_selector_lists.css', __dir__)
+      end
+
       def bootstrap_css
         @bootstrap_css ||= File.read(bootstrap_path)
+      end
+
+      def compact_css
+        @compact_css ||= File.read(compact_path)
+      end
+
+      def nested_css
+        @nested_css ||= File.read(nested_path)
+      end
+
+      def selector_lists_css
+        @selector_lists_css ||= File.read(selector_lists_path)
       end
     end.new
 
     {
       'test_cases' => [
         {
-          'name' => "Full Serialization (Bootstrap CSS - #{(instance.bootstrap_css.length / 1024.0).round}KB)",
-          'key' => 'all',
-          'bytes' => instance.bootstrap_css.length
+          'name' => "to_s (Bootstrap - #{(instance.bootstrap_css.length / 1024.0).round}KB)",
+          'key' => 'bootstrap_compact',
+          'bytes' => instance.bootstrap_css.length,
+          'method' => 'to_s'
         },
         {
-          'name' => 'Media Type Filtering (print only)',
-          'key' => 'print',
-          'bytes' => instance.bootstrap_css.length
+          'name' => "to_s (Compact utilities - #{(instance.compact_css.length / 1024.0).round(1)}KB)",
+          'key' => 'compact',
+          'bytes' => instance.compact_css.length,
+          'method' => 'to_s'
+        },
+        {
+          'name' => "to_formatted_s (Nested CSS - #{(instance.nested_css.length / 1024.0).round(1)}KB)",
+          'key' => 'formatted_nested',
+          'bytes' => instance.nested_css.length,
+          'method' => 'to_formatted_s'
+        },
+        {
+          'name' => "to_s with selector_lists (#{(instance.selector_lists_css.length / 1024.0).round(1)}KB)",
+          'key' => 'selector_lists',
+          'bytes' => instance.selector_lists_css.length,
+          'method' => 'to_s',
+          'selector_lists' => true
+        },
+        {
+          'name' => 'Media filtering (Bootstrap print only)',
+          'key' => 'media_print',
+          'bytes' => instance.bootstrap_css.length,
+          'method' => 'to_s',
+          'media' => 'print'
         }
       ]
     }
@@ -53,8 +99,11 @@ module SerializationTests
   end
 
   def sanity_checks
-    # Verify Bootstrap fixture exists
+    # Verify fixtures exist
     raise "Bootstrap CSS fixture not found at #{bootstrap_path}" unless File.exist?(bootstrap_path)
+    raise "Compact CSS fixture not found at #{compact_path}" unless File.exist?(compact_path)
+    raise "Nested CSS fixture not found at #{nested_path}" unless File.exist?(nested_path)
+    raise "Selector lists CSS fixture not found at #{selector_lists_path}" unless File.exist?(selector_lists_path)
 
     case base_impl_type
     when :pure, :native
@@ -68,11 +117,18 @@ module SerializationTests
       # Verify output can be re-parsed
       reparsed = Cataract.parse_css(cataract_output)
       raise 'Failed to re-parse serialized output' if reparsed.empty?
+
+      # Verify to_formatted_s works
+      formatted = cataract_sheet.to_formatted_s
+      raise 'Formatted serialization produced empty output' if formatted.empty?
     end
   end
 
   def call
-    run_full_serialization_benchmark
+    run_bootstrap_compact_benchmark
+    run_compact_benchmark
+    run_formatted_nested_benchmark
+    run_selector_lists_benchmark
     run_media_filtering_benchmark
   end
 
@@ -80,10 +136,34 @@ module SerializationTests
     @bootstrap_css ||= File.read(bootstrap_path)
   end
 
+  def compact_css
+    @compact_css ||= File.read(compact_path)
+  end
+
+  def nested_css
+    @nested_css ||= File.read(nested_path)
+  end
+
+  def selector_lists_css
+    @selector_lists_css ||= File.read(selector_lists_path)
+  end
+
   private
 
   def bootstrap_path
     @bootstrap_path ||= File.expand_path('../test/fixtures/bootstrap.css', __dir__)
+  end
+
+  def compact_path
+    @compact_path ||= File.expand_path('../test/fixtures/serialization_compact.css', __dir__)
+  end
+
+  def nested_path
+    @nested_path ||= File.expand_path('../test/fixtures/serialization_nested.css', __dir__)
+  end
+
+  def selector_lists_path
+    @selector_lists_path ||= File.expand_path('../test/fixtures/serialization_selector_lists.css', __dir__)
   end
 
   def implementation_label
@@ -103,61 +183,93 @@ module SerializationTests
     "#{base_label}#{yjit_suffix}"
   end
 
-  def run_full_serialization_benchmark
+  def run_bootstrap_compact_benchmark
     puts '=' * 80
-    puts "TEST: Full serialization (to_s) - #{implementation_label}"
+    puts "TEST: to_s (Bootstrap) - #{implementation_label}"
     puts '=' * 80
     puts '(Parsing done once before benchmark, not included in measurements)'
 
-    benchmark('all') do |x|
+    benchmark('bootstrap_compact') do |x|
       x.config(time: 5, warmup: 2)
 
-      case base_impl_type
-      when :pure
-        # Pre-parse CSS once
-        cataract_parsed = Cataract.parse_css(bootstrap_css)
+      # Pre-parse CSS once
+      cataract_parsed = Cataract.parse_css(bootstrap_css)
 
-        x.report('cataract pure: all') do
-          cataract_parsed.to_s
-        end
+      x.report("#{base_impl_type}: bootstrap_compact") do
+        cataract_parsed.to_s
+      end
+    end
+  end
 
-      when :native
-        # Pre-parse CSS once
-        cataract_parsed = Cataract.parse_css(bootstrap_css)
+  def run_compact_benchmark
+    puts "\n#{'=' * 80}"
+    puts "TEST: to_s (Compact utilities) - #{implementation_label}"
+    puts '=' * 80
+    puts '(Many simple rules, minimal whitespace when serialized)'
 
-        x.report('cataract: all') do
-          cataract_parsed.to_s
-        end
+    benchmark('compact') do |x|
+      x.config(time: 5, warmup: 2)
+
+      # Pre-parse CSS once
+      cataract_parsed = Cataract.parse_css(compact_css)
+
+      x.report("#{base_impl_type}: compact") do
+        cataract_parsed.to_s
+      end
+    end
+  end
+
+  def run_formatted_nested_benchmark
+    puts "\n#{'=' * 80}"
+    puts "TEST: to_formatted_s (Nested CSS) - #{implementation_label}"
+    puts '=' * 80
+    puts '(Nested selectors and media queries, formatted with indentation)'
+
+    benchmark('formatted_nested') do |x|
+      x.config(time: 5, warmup: 2)
+
+      # Pre-parse CSS once
+      cataract_parsed = Cataract.parse_css(nested_css)
+
+      x.report("#{base_impl_type}: formatted_nested") do
+        cataract_parsed.to_formatted_s
+      end
+    end
+  end
+
+  def run_selector_lists_benchmark
+    puts "\n#{'=' * 80}"
+    puts "TEST: to_s with selector_lists tracking - #{implementation_label}"
+    puts '=' * 80
+    puts '(Many comma-separated selector lists to test tracking overhead)'
+
+    benchmark('selector_lists') do |x|
+      x.config(time: 5, warmup: 2)
+
+      # Pre-parse CSS once with selector_lists enabled
+      cataract_parsed = Cataract::Stylesheet.parse(selector_lists_css, parser: { selector_lists: true })
+
+      x.report("#{base_impl_type}: selector_lists") do
+        cataract_parsed.to_s
       end
     end
   end
 
   def run_media_filtering_benchmark
     puts "\n#{'=' * 80}"
-    puts "TEST: Media type filtering - to_s(:print) - #{implementation_label}"
+    puts "TEST: Media filtering - to_s(media: :print) - #{implementation_label}"
     puts '=' * 80
+    puts '(Bootstrap CSS filtered to print media only)'
 
-    benchmark('print') do |x|
+    benchmark('media_print') do |x|
       x.config(time: 5, warmup: 2)
 
-      case base_impl_type
-      when :pure
-        # Use Stylesheet API for media filtering
-        cataract_parser = Cataract::Stylesheet.new
-        cataract_parser.add_block(bootstrap_css)
+      # Use Stylesheet API for media filtering
+      cataract_parser = Cataract::Stylesheet.new
+      cataract_parser.add_block(bootstrap_css)
 
-        x.report('cataract pure: print') do
-          cataract_parser.to_s(media: :print)
-        end
-
-      when :native
-        # Use Stylesheet API for media filtering
-        cataract_parser = Cataract::Stylesheet.new
-        cataract_parser.add_block(bootstrap_css)
-
-        x.report('cataract: print') do
-          cataract_parser.to_s(media: :print)
-        end
+      x.report("#{base_impl_type}: media_print") do
+        cataract_parser.to_s(media: :print)
       end
     end
   end

--- a/benchmarks/serialization_tests.rb
+++ b/benchmarks/serialization_tests.rb
@@ -57,12 +57,6 @@ module SerializationTests
     raise "Bootstrap CSS fixture not found at #{bootstrap_path}" unless File.exist?(bootstrap_path)
 
     case base_impl_type
-    when :css_parser
-      require 'css_parser'
-      # Basic sanity check
-      parser = CssParser::Parser.new
-      parser.add_block!(bootstrap_css)
-      raise 'css_parser sanity check failed' if parser.to_s.empty?
     when :pure, :native
       # Verify parsing and serialization work
       cataract_sheet = Cataract.parse_css(bootstrap_css)
@@ -94,8 +88,6 @@ module SerializationTests
 
   def implementation_label
     base_label = case base_impl_type
-                 when :css_parser
-                   'css_parser gem'
                  when :pure
                    'cataract pure'
                  when :native
@@ -121,15 +113,6 @@ module SerializationTests
       x.config(time: 5, warmup: 2)
 
       case base_impl_type
-      when :css_parser
-        # Pre-parse CSS once (outside benchmark loop)
-        css_parser_parsed = CssParser::Parser.new
-        css_parser_parsed.add_block!(bootstrap_css)
-
-        x.report('css_parser gem: all') do
-          css_parser_parsed.to_s
-        end
-
       when :pure
         # Pre-parse CSS once
         cataract_parsed = Cataract.parse_css(bootstrap_css)
@@ -158,14 +141,6 @@ module SerializationTests
       x.config(time: 5, warmup: 2)
 
       case base_impl_type
-      when :css_parser
-        css_parser_for_filter = CssParser::Parser.new
-        css_parser_for_filter.add_block!(bootstrap_css)
-
-        x.report('css_parser gem: print') do
-          css_parser_for_filter.to_s(:print)
-        end
-
       when :pure
         # Use Stylesheet API for media filtering
         cataract_parser = Cataract::Stylesheet.new

--- a/benchmarks/specificity_tests.rb
+++ b/benchmarks/specificity_tests.rb
@@ -34,8 +34,7 @@ module SpecificityTests
         {
           'name' => ':not() Pseudo-class (CSS3)',
           'key' => 'not',
-          'selectors' => { '#s12:not(foo)' => 101, 'div:not(.active)' => 11, '.button:not([disabled])' => 20 },
-          'note' => "css_parser has a bug - doesn't parse :not() content"
+          'selectors' => { '#s12:not(foo)' => 101, 'div:not(.active)' => 11, '.button:not([disabled])' => 20 }
         },
         {
           'name' => 'Complex Real-world Selectors',
@@ -69,12 +68,6 @@ module SpecificityTests
 
   def sanity_checks
     case base_impl_type
-    when :css_parser
-      require 'css_parser'
-      # Verify css_parser calculations
-      raise 'css_parser simple selector failed' unless CssParser.calculate_specificity('div') == 1
-      raise 'css_parser class selector failed' unless CssParser.calculate_specificity('.class') == 10
-      raise 'css_parser id selector failed' unless CssParser.calculate_specificity('#id') == 100
     when :pure, :native
       # Verify Cataract calculations
       raise 'Cataract simple selector failed' unless Cataract.calculate_specificity('div') == 1
@@ -93,8 +86,6 @@ module SpecificityTests
 
   def implementation_label
     base_label = case base_impl_type
-                 when :css_parser
-                   'css_parser gem'
                  when :pure
                    'cataract pure'
                  when :native
@@ -130,13 +121,6 @@ module SpecificityTests
       x.config(time: 2, warmup: 1)
 
       case base_impl_type
-      when :css_parser
-        x.report("css_parser gem: #{key}") do
-          selectors.each_key do |selector|
-            CssParser.calculate_specificity(selector)
-          end
-        end
-
       when :pure
         x.report("cataract pure: #{key}") do
           selectors.each_key do |selector|

--- a/benchmarks/speedup_calculator.rb
+++ b/benchmarks/speedup_calculator.rb
@@ -4,12 +4,12 @@
 # Compares "baseline" vs "comparison" results and calculates speedup stats
 #
 # CONVENTION: Result names must use format "tool_name: test_case_id"
-# Example: "css_parser: CSS1", "cataract: CSS1"
+# Example: "pure_without_yjit: CSS1", "native: CSS1"
 class SpeedupCalculator
   # @param results [Array<Hash>] Array of benchmark results with 'name' and 'central_tendency'
   # @param test_cases [Array<Hash>] Array of test case metadata to annotate with speedups
-  # @param baseline_matcher [Proc] Block that returns true if result is baseline (e.g., css_parser)
-  # @param comparison_matcher [Proc] Block that returns true if result is comparison (e.g., cataract)
+  # @param baseline_matcher [Proc] Block that returns true if result is baseline (e.g., pure Ruby)
+  # @param comparison_matcher [Proc] Block that returns true if result is comparison (e.g., native C)
   # @param test_case_key [Symbol] Key in test_cases hash to match against test case id from result name
   def initialize(results:, test_cases:, baseline_matcher:, comparison_matcher:, test_case_key: nil)
     @results = results
@@ -56,18 +56,14 @@ class SpeedupCalculator
   private
 
   # Extract test case id from result name
-  # "css_parser: CSS1" -> "CSS1"
-  # "cataract gem: all" -> "all"
+  # "pure_without_yjit: CSS1" -> "CSS1"
+  # "native: all" -> "all"
   def extract_test_case(name)
     name.split(':').last.strip
   end
 
   # Common matchers
   class Matchers
-    def self.css_parser
-      ->(result) { base_implementation(result) == 'css_parser' }
-    end
-
     def self.cataract
       # Matches native cataract (for backwards compatibility)
       ->(result) { base_implementation(result) == 'native' }

--- a/benchmarks/templates/benchmarks.md.erb
+++ b/benchmarks/templates/benchmarks.md.erb
@@ -4,7 +4,7 @@
 
 # Performance Benchmarks
 
-Performance comparison between Cataract's C extension and pure Ruby implementations, with css_parser as a reference.
+Performance comparison between Cataract's C extension and pure Ruby implementations.
 
 ## Test Environment
 
@@ -19,36 +19,21 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 
 <%= parsing_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
-|-----------|--------|----------------|-------------|----------------------|-------------------|
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
+|-----------|--------|----------------|-------------|
 <%- parsing_data['metadata']['test_cases'].each do |test_case| -%>
 <%- results = parsing_data['results'].select { |r| r['name'].include?(test_case['fixture']) } -%>
 <%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
 <%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
 <%- native = results.find { |r| r['implementation'] == 'native' } -%>
-<%- css_no_yjit = results.find { |r| r['implementation'] == 'css_parser_without_yjit' } -%>
-<%- css_with_yjit = results.find { |r| r['implementation'] == 'css_parser_with_yjit' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= css_no_yjit ? format_ips(css_no_yjit, short: true) : 'N/A' %> | <%= css_with_yjit ? format_ips(css_with_yjit, short: true) : 'N/A' %> |
+| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> |
 <%- end -%>
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-<%- if parsing_data['metadata']['speedups'] -%>
-| Native vs Pure (no YJIT) | <%= format_speedup(parsing_data['metadata']['speedups']['avg']) %> (avg) |
-<%- end -%>
-<%- # Calculate Native vs Pure with YJIT -%>
-<%- pure_with_yjit_avg = parsing_data['results'].select { |r| r['implementation'] == 'pure_with_yjit' }.map { |r| r['central_tendency'] }.sum / [parsing_data['results'].select { |r| r['implementation'] == 'pure_with_yjit' }.size, 1].max -%>
-<%- native_avg = parsing_data['results'].select { |r| r['implementation'] == 'native' }.map { |r| r['central_tendency'] }.sum / [parsing_data['results'].select { |r| r['implementation'] == 'native' }.size, 1].max -%>
-<%- if pure_with_yjit_avg > 0 && native_avg > 0 -%>
-| Native vs Pure (YJIT) | <%= format_speedup(native_avg / pure_with_yjit_avg) %> (avg) |
-<%- end -%>
-<%- # Calculate YJIT impact on pure Ruby -%>
-<%- pure_no_yjit_avg = parsing_data['results'].select { |r| r['implementation'] == 'pure_without_yjit' }.map { |r| r['central_tendency'] }.sum / [parsing_data['results'].select { |r| r['implementation'] == 'pure_without_yjit' }.size, 1].max -%>
-<%- if pure_no_yjit_avg > 0 && pure_with_yjit_avg > 0 -%>
-| YJIT impact on Pure Ruby | <%= format_speedup(pure_with_yjit_avg / pure_no_yjit_avg) %> (avg) |
-<%- end -%>
+<%= speedup_rows(parsing_data, test_case_key: :fixture) %>
 
 ---
 <%- end -%>
@@ -58,36 +43,21 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 
 <%= serialization_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
-|-----------|--------|----------------|-------------|----------------------|-------------------|
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
+|-----------|--------|----------------|-------------|
 <%- serialization_data['metadata']['test_cases'].each do |test_case| -%>
 <%- results = serialization_data['results'].select { |r| r['name'].include?(test_case['key']) } -%>
 <%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
 <%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
 <%- native = results.find { |r| r['implementation'] == 'native' } -%>
-<%- css_no_yjit = results.find { |r| r['implementation'] == 'css_parser_without_yjit' } -%>
-<%- css_with_yjit = results.find { |r| r['implementation'] == 'css_parser_with_yjit' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= css_no_yjit ? format_ips(css_no_yjit, short: true) : 'N/A' %> | <%= css_with_yjit ? format_ips(css_with_yjit, short: true) : 'N/A' %> |
+| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> |
 <%- end -%>
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-<%- if serialization_data['metadata']['speedups'] -%>
-| Native vs Pure (no YJIT) | <%= format_speedup(serialization_data['metadata']['speedups']['avg']) %> (avg) |
-<%- end -%>
-<%- # Calculate Native vs Pure with YJIT -%>
-<%- pure_with_yjit_avg = serialization_data['results'].select { |r| r['implementation'] == 'pure_with_yjit' }.map { |r| r['central_tendency'] }.sum / [serialization_data['results'].select { |r| r['implementation'] == 'pure_with_yjit' }.size, 1].max -%>
-<%- native_avg = serialization_data['results'].select { |r| r['implementation'] == 'native' }.map { |r| r['central_tendency'] }.sum / [serialization_data['results'].select { |r| r['implementation'] == 'native' }.size, 1].max -%>
-<%- if pure_with_yjit_avg > 0 && native_avg > 0 -%>
-| Native vs Pure (YJIT) | <%= format_speedup(native_avg / pure_with_yjit_avg) %> (avg) |
-<%- end -%>
-<%- # Calculate YJIT impact on pure Ruby -%>
-<%- pure_no_yjit_avg = serialization_data['results'].select { |r| r['implementation'] == 'pure_without_yjit' }.map { |r| r['central_tendency'] }.sum / [serialization_data['results'].select { |r| r['implementation'] == 'pure_without_yjit' }.size, 1].max -%>
-<%- if pure_no_yjit_avg > 0 && pure_with_yjit_avg > 0 -%>
-| YJIT impact on Pure Ruby | <%= format_speedup(pure_with_yjit_avg / pure_no_yjit_avg) %> (avg) |
-<%- end -%>
+<%= speedup_rows(serialization_data, test_case_key: :key) %>
 
 ---
 <%- end -%>
@@ -97,36 +67,21 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 
 <%= specificity_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
-|-----------|--------|----------------|-------------|----------------------|-------------------|
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
+|-----------|--------|----------------|-------------|
 <%- specificity_data['metadata']['test_cases'].each do |test_case| -%>
 <%- results = specificity_data['results'].select { |r| r['name'].include?(test_case['key']) } -%>
 <%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
 <%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
 <%- native = results.find { |r| r['implementation'] == 'native' } -%>
-<%- css_no_yjit = results.find { |r| r['implementation'] == 'css_parser_without_yjit' } -%>
-<%- css_with_yjit = results.find { |r| r['implementation'] == 'css_parser_with_yjit' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= css_no_yjit ? format_ips(css_no_yjit, short: true) : 'N/A' %> | <%= css_with_yjit ? format_ips(css_with_yjit, short: true) : 'N/A' %> |
+| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> |
 <%- end -%>
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-<%- if specificity_data['metadata']['speedups'] -%>
-| Native vs Pure (no YJIT) | <%= format_speedup(specificity_data['metadata']['speedups']['avg']) %> (avg) |
-<%- end -%>
-<%- # Calculate Native vs Pure with YJIT -%>
-<%- pure_with_yjit_avg = specificity_data['results'].select { |r| r['implementation'] == 'pure_with_yjit' }.map { |r| r['central_tendency'] }.sum / [specificity_data['results'].select { |r| r['implementation'] == 'pure_with_yjit' }.size, 1].max -%>
-<%- native_avg = specificity_data['results'].select { |r| r['implementation'] == 'native' }.map { |r| r['central_tendency'] }.sum / [specificity_data['results'].select { |r| r['implementation'] == 'native' }.size, 1].max -%>
-<%- if pure_with_yjit_avg > 0 && native_avg > 0 -%>
-| Native vs Pure (YJIT) | <%= format_speedup(native_avg / pure_with_yjit_avg) %> (avg) |
-<%- end -%>
-<%- # Calculate YJIT impact on pure Ruby -%>
-<%- pure_no_yjit_avg = specificity_data['results'].select { |r| r['implementation'] == 'pure_without_yjit' }.map { |r| r['central_tendency'] }.sum / [specificity_data['results'].select { |r| r['implementation'] == 'pure_without_yjit' }.size, 1].max -%>
-<%- if pure_no_yjit_avg > 0 && pure_with_yjit_avg > 0 -%>
-| YJIT impact on Pure Ruby | <%= format_speedup(pure_with_yjit_avg / pure_no_yjit_avg) %> (avg) |
-<%- end -%>
+<%= speedup_rows(specificity_data, test_case_key: :key) %>
 
 ---
 <%- end -%>
@@ -136,36 +91,21 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 
 <%= flattening_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | css_parser (no YJIT) | css_parser (YJIT) |
-|-----------|--------|----------------|-------------|----------------------|-------------------|
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
+|-----------|--------|----------------|-------------|
 <%- flattening_data['metadata']['test_cases'].each do |test_case| -%>
 <%- results = flattening_data['results'].select { |r| r['name'].include?(test_case['key']) } -%>
 <%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
 <%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
 <%- native = results.find { |r| r['implementation'] == 'native' } -%>
-<%- css_no_yjit = results.find { |r| r['implementation'] == 'css_parser_without_yjit' } -%>
-<%- css_with_yjit = results.find { |r| r['implementation'] == 'css_parser_with_yjit' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= css_no_yjit ? format_ips(css_no_yjit, short: true) : 'N/A' %> | <%= css_with_yjit ? format_ips(css_with_yjit, short: true) : 'N/A' %> |
+| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> |
 <%- end -%>
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-<%- if flattening_data['metadata']['speedups'] -%>
-| Native vs Pure (no YJIT) | <%= format_speedup(flattening_data['metadata']['speedups']['avg']) %> (avg) |
-<%- end -%>
-<%- # Calculate Native vs Pure with YJIT -%>
-<%- pure_with_yjit_avg = flattening_data['results'].select { |r| r['implementation'] == 'pure_with_yjit' }.map { |r| r['central_tendency'] }.sum / [flattening_data['results'].select { |r| r['implementation'] == 'pure_with_yjit' }.size, 1].max -%>
-<%- native_avg = flattening_data['results'].select { |r| r['implementation'] == 'native' }.map { |r| r['central_tendency'] }.sum / [flattening_data['results'].select { |r| r['implementation'] == 'native' }.size, 1].max -%>
-<%- if pure_with_yjit_avg > 0 && native_avg > 0 -%>
-| Native vs Pure (YJIT) | <%= format_speedup(native_avg / pure_with_yjit_avg) %> (avg) |
-<%- end -%>
-<%- # Calculate YJIT impact on pure Ruby -%>
-<%- pure_no_yjit_avg = flattening_data['results'].select { |r| r['implementation'] == 'pure_without_yjit' }.map { |r| r['central_tendency'] }.sum / [flattening_data['results'].select { |r| r['implementation'] == 'pure_without_yjit' }.size, 1].max -%>
-<%- if pure_no_yjit_avg > 0 && pure_with_yjit_avg > 0 -%>
-| YJIT impact on Pure Ruby | <%= format_speedup(pure_with_yjit_avg / pure_no_yjit_avg) %> (avg) |
-<%- end -%>
+<%= speedup_rows(flattening_data, test_case_key: :key) %>
 
 ---
 <%- end -%>
@@ -190,5 +130,4 @@ rake benchmark:generate_docs
 
 - Benchmarks use benchmark-ips with 1-2s warmup and 2-5s measurement periods
 - Measurements show median iterations per second (i/s)
-- css_parser gem is included for reference comparison
 - YJIT is enabled/disabled per subprocess for accurate comparison

--- a/benchmarks/worker_helpers.rb
+++ b/benchmarks/worker_helpers.rb
@@ -16,7 +16,7 @@ module WorkerHelpers
 
   # Determines implementation type with YJIT suffix based on actual YJIT status
   #
-  # @param base_impl [Symbol] Base implementation (:css_parser, :pure, :native)
+  # @param base_impl [Symbol] Base implementation (:pure, :native)
   # @param test_module [Module] Test module that provides yjit_applicable? method
   # @return [Symbol] Implementation type with YJIT suffix if applicable
   #

--- a/ext/cataract/cataract.c
+++ b/ext/cataract/cataract.c
@@ -609,9 +609,11 @@ static void serialize_rule_with_children(VALUE result, VALUE rules_array, long r
 }
 
 // New stylesheet serialization entry point - checks for nesting and delegates
-static VALUE stylesheet_to_s_new(VALUE self, VALUE rules_array, VALUE media_index, VALUE charset, VALUE has_nesting) {
+static VALUE stylesheet_to_s_new(VALUE self, VALUE rules_array, VALUE media_index, VALUE charset, VALUE has_nesting, VALUE selector_lists) {
     Check_Type(rules_array, T_ARRAY);
     Check_Type(media_index, T_HASH);
+    // TODO: Phase 2 - use selector_lists for grouping
+    (void)selector_lists; // Suppress unused parameter warning
 
     // Fast path: if no nesting, use original implementation (zero overhead)
     if (!RTEST(has_nesting)) {
@@ -805,9 +807,11 @@ static VALUE stylesheet_to_formatted_s_original(VALUE rules_array, VALUE media_i
 }
 
 // Formatted version with indentation and newlines (with nesting support)
-static VALUE stylesheet_to_formatted_s_new(VALUE self, VALUE rules_array, VALUE media_index, VALUE charset, VALUE has_nesting) {
+static VALUE stylesheet_to_formatted_s_new(VALUE self, VALUE rules_array, VALUE media_index, VALUE charset, VALUE has_nesting, VALUE selector_lists) {
     Check_Type(rules_array, T_ARRAY);
     Check_Type(media_index, T_HASH);
+    // TODO: Phase 2 - use selector_lists for grouping
+    (void)selector_lists; // Suppress unused parameter warning
 
     // Fast path: if no nesting, use original implementation (zero overhead)
     if (!RTEST(has_nesting)) {
@@ -1177,8 +1181,8 @@ void Init_native_extension(void) {
 
     // Define module functions
     rb_define_module_function(mCataract, "_parse_css", parse_css_new, -1);
-    rb_define_module_function(mCataract, "_stylesheet_to_s", stylesheet_to_s_new, 4);
-    rb_define_module_function(mCataract, "_stylesheet_to_formatted_s", stylesheet_to_formatted_s_new, 4);
+    rb_define_module_function(mCataract, "_stylesheet_to_s", stylesheet_to_s_new, 5);
+    rb_define_module_function(mCataract, "_stylesheet_to_formatted_s", stylesheet_to_formatted_s_new, 5);
     rb_define_module_function(mCataract, "parse_media_types", parse_media_types, 1);
     rb_define_module_function(mCataract, "parse_declarations", new_parse_declarations, 1);
     rb_define_module_function(mCataract, "flatten", cataract_flatten, 1);

--- a/ext/cataract/cataract.c
+++ b/ext/cataract/cataract.c
@@ -32,10 +32,21 @@ VALUE eSizeError;
  * This matches the old parse_css API
  *
  * @param css_string [String] CSS to parse
+ * @param parser_options [Hash] Parser options (optional, defaults to {})
  * @return [Hash] { rules: [...], media_index: {...}, charset: "..." }
  */
-VALUE parse_css_new(VALUE self, VALUE css_string) {
-    return parse_css_new_impl(css_string, 0);
+VALUE parse_css_new(int argc, VALUE *argv, VALUE self) {
+    VALUE css_string, parser_options;
+
+    // Parse arguments: required css_string, optional parser_options hash
+    rb_scan_args(argc, argv, "11", &css_string, &parser_options);
+
+    // Default to empty hash if not provided
+    if (NIL_P(parser_options)) {
+        parser_options = rb_hash_new();
+    }
+
+    return parse_css_new_impl(css_string, parser_options, 0);
 }
 
 /*
@@ -1165,7 +1176,7 @@ void Init_native_extension(void) {
     cStylesheet = rb_define_class_under(mCataract, "Stylesheet", rb_cObject);
 
     // Define module functions
-    rb_define_module_function(mCataract, "_parse_css", parse_css_new, 1);
+    rb_define_module_function(mCataract, "_parse_css", parse_css_new, -1);
     rb_define_module_function(mCataract, "_stylesheet_to_s", stylesheet_to_s_new, 4);
     rb_define_module_function(mCataract, "_stylesheet_to_formatted_s", stylesheet_to_formatted_s_new, 4);
     rb_define_module_function(mCataract, "parse_media_types", parse_media_types, 1);

--- a/ext/cataract/cataract.h
+++ b/ext/cataract/cataract.h
@@ -23,13 +23,14 @@ extern VALUE eSizeError;
 // Struct field indices
 // ============================================================================
 
-// Rule struct field indices (id, selector, declarations, specificity, parent_rule_id, nesting_style)
+// Rule struct field indices (id, selector, declarations, specificity, parent_rule_id, nesting_style, selector_list_id)
 #define RULE_ID 0
 #define RULE_SELECTOR 1
 #define RULE_DECLARATIONS 2
 #define RULE_SPECIFICITY 3
 #define RULE_PARENT_RULE_ID 4
 #define RULE_NESTING_STYLE 5
+#define RULE_SELECTOR_LIST_ID 6
 
 // Nesting style constants
 #define NESTING_STYLE_IMPLICIT 0  // .parent { .child { } } - no &

--- a/ext/cataract/cataract.h
+++ b/ext/cataract/cataract.h
@@ -141,8 +141,8 @@ static inline VALUE strip_string(const char *str, long len) {
 // ============================================================================
 
 // CSS parser (css_parser_new.c)
-VALUE parse_css_new(VALUE self, VALUE css_string);
-VALUE parse_css_new_impl(VALUE css_string, int rule_id_offset);
+VALUE parse_css_new(int argc, VALUE *argv, VALUE self);
+VALUE parse_css_new_impl(VALUE css_string, VALUE parser_options, int rule_id_offset);
 VALUE parse_media_types(VALUE self, VALUE media_query_sym);
 
 // Flatten (flatten.c)

--- a/ext/cataract/css_parser.c
+++ b/ext/cataract/css_parser.c
@@ -17,11 +17,14 @@
 typedef struct {
     VALUE rules_array;        // Array of Rule structs
     VALUE media_index;        // Hash: Symbol => Array of rule IDs
+    VALUE selector_lists;     // Hash: list_id => Array of rule IDs
     VALUE imports_array;      // Array of ImportStatement structs
     int rule_id_counter;      // Next rule ID (0-indexed)
+    int next_selector_list_id; // Next selector list ID (0-indexed)
     int media_query_count;    // Safety limit for media queries
     st_table *media_cache;    // Parse-time cache: string => parsed media types
     int has_nesting;          // Set to 1 if any nested rules are created
+    int selector_lists_enabled; // Parser option: track selector lists (1=enabled, 0=disabled)
     int depth;                // Current recursion depth (safety limit)
 } ParserContext;
 
@@ -691,7 +694,8 @@ static VALUE parse_mixed_block(ParserContext *ctx, const char *start, const char
                 media_declarations,
                 Qnil,  // specificity
                 parent_rule_id,  // Link to parent for nested @media serialization
-                Qnil   // nesting_style (nil for @media nesting)
+                Qnil,  // nesting_style (nil for @media nesting)
+                Qnil   // selector_list_id
             );
 
             // Mark that we have nesting (only set once)
@@ -773,7 +777,8 @@ static VALUE parse_mixed_block(ParserContext *ctx, const char *start, const char
                             nested_declarations,
                             Qnil,  // specificity
                             parent_rule_id,
-                            nesting_style
+                            nesting_style,
+                            Qnil   // selector_list_id
                         );
 
                         // Mark that we have nesting (only set once)
@@ -1158,10 +1163,14 @@ static void parse_css_recursive(ParserContext *ctx, const char *css, const char 
                 ParserContext nested_ctx = {
                     .rules_array = rb_ary_new(),
                     .media_index = rb_hash_new(),
+                    .selector_lists = rb_hash_new(),
+                    .imports_array = rb_ary_new(),
                     .rule_id_counter = 0,
+                    .next_selector_list_id = 0,
                     .media_query_count = 0,
                     .media_cache = NULL,
                     .has_nesting = 0,
+                    .selector_lists_enabled = ctx->selector_lists_enabled,
                     .depth = 0
                 };
                 parse_css_recursive(&nested_ctx, block_start, block_end, NO_PARENT_MEDIA, NO_PARENT_SELECTOR, NO_PARENT_RULE_ID);
@@ -1283,6 +1292,28 @@ static void parse_css_recursive(ParserContext *ctx, const char *css, const char 
                     // Example: ".a, .b, .c { color: red; }" creates 3 separate rules
                     //           ^selector_start      ^sel_end
                     //              ^seg_start=seg (scanning for commas)
+
+                    // Count selectors for selector list tracking
+                    int selector_count = 1;
+                    if (ctx->selector_lists_enabled) {
+                        const char *count_ptr = selector_start;
+                        while (count_ptr < sel_end) {
+                            if (*count_ptr == ',') {
+                                selector_count++;
+                            }
+                            count_ptr++;
+                        }
+                    }
+
+                    // Create selector list if enabled and multiple selectors
+                    int list_id = -1;
+                    VALUE rule_ids_array = Qnil;
+                    if (ctx->selector_lists_enabled && selector_count > 1) {
+                        list_id = ctx->next_selector_list_id++;
+                        rule_ids_array = rb_ary_new();
+                        rb_hash_aset(ctx->selector_lists, INT2FIX(list_id), rule_ids_array);
+                    }
+
                     const char *seg_start = selector_start;
                     const char *seg = selector_start;
 
@@ -1322,6 +1353,9 @@ static void parse_css_recursive(ParserContext *ctx, const char *css, const char 
                                 // Get rule ID and increment
                                 int rule_id = ctx->rule_id_counter++;
 
+                                // Determine selector_list_id value
+                                VALUE selector_list_id_val = (list_id >= 0) ? INT2FIX(list_id) : Qnil;
+
                                 // Create Rule
                                 VALUE rule = rb_struct_new(cRule,
                                     INT2FIX(rule_id),
@@ -1329,8 +1363,14 @@ static void parse_css_recursive(ParserContext *ctx, const char *css, const char 
                                     rb_ary_dup(declarations),
                                     Qnil,  // specificity
                                     parent_id_val,
-                                    nesting_style_val
+                                    nesting_style_val,
+                                    selector_list_id_val
                                 );
+
+                                // Track rule in selector list if applicable
+                                if (list_id >= 0) {
+                                    rb_ary_push(rule_ids_array, INT2FIX(rule_id));
+                                }
 
                                 // Mark that we have nesting (only set once)
                                 if (!ctx->has_nesting && !NIL_P(parent_id_val)) {
@@ -1358,6 +1398,28 @@ static void parse_css_recursive(ParserContext *ctx, const char *css, const char 
                     //   - .a .child with declarations [font: 14px]
                     //   - .b with declarations [color: red]
                     //   - .b .child with declarations [font: 14px]
+
+                    // Count selectors for selector list tracking
+                    int selector_count = 1;
+                    if (ctx->selector_lists_enabled) {
+                        const char *count_ptr = selector_start;
+                        while (count_ptr < sel_end) {
+                            if (*count_ptr == ',') {
+                                selector_count++;
+                            }
+                            count_ptr++;
+                        }
+                    }
+
+                    // Create selector list if enabled and multiple selectors
+                    int list_id = -1;
+                    VALUE rule_ids_array = Qnil;
+                    if (ctx->selector_lists_enabled && selector_count > 1) {
+                        list_id = ctx->next_selector_list_id++;
+                        rule_ids_array = rb_ary_new();
+                        rb_hash_aset(ctx->selector_lists, INT2FIX(list_id), rule_ids_array);
+                    }
+
                     const char *seg_start = selector_start;
                     const char *seg = selector_start;
 
@@ -1407,6 +1469,9 @@ static void parse_css_recursive(ParserContext *ctx, const char *css, const char 
                                                                              resolved_current, INT2FIX(current_rule_id), parent_media_sym);
                                 ctx->depth--;
 
+                                // Determine selector_list_id value
+                                VALUE selector_list_id_val = (list_id >= 0) ? INT2FIX(list_id) : Qnil;
+
                                 // Create parent rule and replace placeholder
                                 // Always create the rule (even if empty) to avoid edge cases
                                 VALUE rule = rb_struct_new(cRule,
@@ -1415,8 +1480,14 @@ static void parse_css_recursive(ParserContext *ctx, const char *css, const char 
                                     parent_declarations,
                                     Qnil,  // specificity
                                     current_parent_id,
-                                    current_nesting_style
+                                    current_nesting_style,
+                                    selector_list_id_val
                                 );
+
+                                // Track rule in selector list if applicable
+                                if (list_id >= 0) {
+                                    rb_ary_push(rule_ids_array, INT2FIX(current_rule_id));
+                                }
 
                                 // Mark that we have nesting (only set once)
                                 if (!ctx->has_nesting && !NIL_P(current_parent_id)) {
@@ -1473,11 +1544,16 @@ VALUE parse_media_types(VALUE self, VALUE media_query_sym) {
  * Main parse entry point
  * Returns: { rules: [...], media_index: {...}, charset: "..." | nil, last_rule_id: N }
  */
-VALUE parse_css_new_impl(VALUE css_string, int rule_id_offset) {
+VALUE parse_css_new_impl(VALUE css_string, VALUE parser_options, int rule_id_offset) {
     Check_Type(css_string, T_STRING);
+    Check_Type(parser_options, T_HASH);
 
     DEBUG_PRINTF("\n[PARSE_NEW] ========== NEW PARSE CALL ==========\n");
     DEBUG_PRINTF("[PARSE_NEW] Input CSS (first 100 chars): %.100s\n", RSTRING_PTR(css_string));
+
+    // Read parser options
+    VALUE selector_lists_opt = rb_hash_aref(parser_options, ID2SYM(rb_intern("selector_lists")));
+    int selector_lists_enabled = (NIL_P(selector_lists_opt) || RTEST(selector_lists_opt)) ? 1 : 0;
 
     const char *css = RSTRING_PTR(css_string);
     const char *pe = css + RSTRING_LEN(css_string);
@@ -1513,11 +1589,14 @@ VALUE parse_css_new_impl(VALUE css_string, int rule_id_offset) {
     ParserContext ctx;
     ctx.rules_array = rb_ary_new();
     ctx.media_index = rb_hash_new();
+    ctx.selector_lists = rb_hash_new();
     ctx.imports_array = rb_ary_new();
     ctx.rule_id_counter = rule_id_offset;  // Start from offset
+    ctx.next_selector_list_id = 0;  // Start from 0
     ctx.media_query_count = 0;
     ctx.media_cache = NULL;  // Removed - no perf benefit
     ctx.has_nesting = 0;  // Will be set to 1 if any nested rules are created
+    ctx.selector_lists_enabled = selector_lists_enabled;
     ctx.depth = 0;  // Start at depth 0
 
     // Parse CSS (top-level, no parent context)
@@ -1528,6 +1607,7 @@ VALUE parse_css_new_impl(VALUE css_string, int rule_id_offset) {
     VALUE result = rb_hash_new();
     rb_hash_aset(result, ID2SYM(rb_intern("rules")), ctx.rules_array);
     rb_hash_aset(result, ID2SYM(rb_intern("_media_index")), ctx.media_index);
+    rb_hash_aset(result, ID2SYM(rb_intern("_selector_lists")), ctx.selector_lists);
     rb_hash_aset(result, ID2SYM(rb_intern("imports")), ctx.imports_array);
     rb_hash_aset(result, ID2SYM(rb_intern("charset")), charset);
     rb_hash_aset(result, ID2SYM(rb_intern("last_rule_id")), INT2FIX(ctx.rule_id_counter));
@@ -1536,6 +1616,7 @@ VALUE parse_css_new_impl(VALUE css_string, int rule_id_offset) {
     RB_GC_GUARD(charset);
     RB_GC_GUARD(ctx.rules_array);
     RB_GC_GUARD(ctx.media_index);
+    RB_GC_GUARD(ctx.selector_lists);
     RB_GC_GUARD(ctx.imports_array);
     RB_GC_GUARD(result);
 

--- a/ext/cataract/flatten.c
+++ b/ext/cataract/flatten.c
@@ -1025,7 +1025,8 @@ VALUE cataract_flatten(VALUE self, VALUE input) {
     // Most calls pass Stylesheet (common case), String is rare
     if (TYPE(input) == T_STRING) {
         // Parse CSS string first
-        VALUE parsed = parse_css_new(self, input);
+        VALUE argv[1] = { input };
+        VALUE parsed = parse_css_new(1, argv, self);
         rules_array = rb_hash_aref(parsed, ID2SYM(rb_intern("rules")));
     } else if (rb_obj_is_kind_of(input, cStylesheet)) {
         // Extract @rules from Stylesheet (common case)

--- a/ext/cataract/flatten.c
+++ b/ext/cataract/flatten.c
@@ -710,11 +710,13 @@ static VALUE flatten_rules_for_selector(VALUE rules_array, VALUE rule_indices, V
     // Set output parameter: preserve selector_list_id only if all rules share same ID
     if (out_selector_list_id) {
         *out_selector_list_id = (all_same_selector_list_id && !NIL_P(first_selector_list_id)) ? first_selector_list_id : Qnil;
+#ifdef CATARACT_DEBUG
         if (!NIL_P(*out_selector_list_id)) {
             DEBUG_PRINTF("    -> Preserving selector_list_id=%ld for merged rule\n", NUM2LONG(*out_selector_list_id));
         } else {
             DEBUG_PRINTF("    -> NOT preserving selector_list_id (not all same)\n");
         }
+#endif
     }
 
     // Process each rule in this selector group
@@ -1141,7 +1143,9 @@ static void update_selector_lists_for_divergence(VALUE merged_rules, VALUE selec
         }
 
         VALUE selector_list_id = rb_struct_aref(rule, INT2FIX(RULE_SELECTOR_LIST_ID));
+#ifdef CATARACT_DEBUG
         VALUE selector = rb_struct_aref(rule, INT2FIX(RULE_SELECTOR));
+#endif
 
         if (NIL_P(selector_list_id)) {
             DEBUG_PRINTF("  Rule %ld (%s): no selector_list_id\n", i, RSTRING_PTR(selector));
@@ -1180,11 +1184,12 @@ static void update_selector_lists_for_divergence(VALUE merged_rules, VALUE selec
 
         // Get first rule as reference
         VALUE reference_rule = RARRAY_AREF(rules_in_list, 0);
-        VALUE reference_selector = rb_struct_aref(reference_rule, INT2FIX(RULE_SELECTOR));
         VALUE reference_decls = rb_struct_aref(reference_rule, INT2FIX(RULE_DECLARATIONS));
-
+#ifdef CATARACT_DEBUG
+        VALUE reference_selector = rb_struct_aref(reference_rule, INT2FIX(RULE_SELECTOR));
         DEBUG_PRINTF("    Reference rule: selector=%s, %ld declarations\n",
                      RSTRING_PTR(reference_selector), RARRAY_LEN(reference_decls));
+#endif
 
         // Find rules that still match (have identical declarations)
         VALUE matching_rules = rb_ary_new();
@@ -1192,10 +1197,11 @@ static void update_selector_lists_for_divergence(VALUE merged_rules, VALUE selec
 
         for (long j = 1; j < num_in_list; j++) {
             VALUE rule = RARRAY_AREF(rules_in_list, j);
-            VALUE selector = rb_struct_aref(rule, INT2FIX(RULE_SELECTOR));
             VALUE decls = rb_struct_aref(rule, INT2FIX(RULE_DECLARATIONS));
-
+#ifdef CATARACT_DEBUG
+            VALUE selector = rb_struct_aref(rule, INT2FIX(RULE_SELECTOR));
             DEBUG_PRINTF("    Comparing rule %ld (selector=%s):\n", j, RSTRING_PTR(selector));
+#endif
 
             if (declarations_equal(reference_decls, decls)) {
                 DEBUG_PRINTF("      -> MATCHES reference, keeping in list\n");
@@ -1502,7 +1508,6 @@ VALUE cataract_flatten(VALUE self, VALUE input) {
                 }
             } else {
                 // Default behavior when parser_options is nil: assume enabled
-                selector_lists_enabled = 1;
                 update_selector_lists_for_divergence(merged_rules, selector_lists);
             }
         }

--- a/ext/cataract/flatten.c
+++ b/ext/cataract/flatten.c
@@ -623,7 +623,7 @@ struct flatten_selectors_context {
 };
 
 // Forward declaration
-static VALUE flatten_rules_for_selector(VALUE rules_array, VALUE rule_indices, VALUE selector);
+static VALUE flatten_rules_for_selector(VALUE rules_array, VALUE rule_indices, VALUE selector, VALUE *out_selector_list_id);
 
 // Callback for rb_hash_foreach when merging selector groups
 static int flatten_selector_group_callback(VALUE selector, VALUE group_indices, VALUE arg) {
@@ -634,8 +634,9 @@ static int flatten_selector_group_callback(VALUE selector, VALUE group_indices, 
                  ctx->selector_index, ctx->total_selectors,
                  RSTRING_PTR(selector), RARRAY_LEN(group_indices));
 
-    // Merge all rules in this selector group
-    VALUE merged_decls = flatten_rules_for_selector(ctx->rules_array, group_indices, selector);
+    // Merge all rules in this selector group and preserve selector_list_id if all rules share same ID
+    VALUE selector_list_id = Qnil;
+    VALUE merged_decls = flatten_rules_for_selector(ctx->rules_array, group_indices, selector, &selector_list_id);
 
     // Create new rule with this selector and merged declarations
     VALUE new_rule = rb_struct_new(cRule,
@@ -645,7 +646,7 @@ static int flatten_selector_group_callback(VALUE selector, VALUE group_indices, 
         Qnil,  // specificity
         Qnil,  // parent_rule_id
         Qnil,  // nesting_style
-        Qnil   // selector_list_id
+        selector_list_id  // Preserve selector_list_id if all rules in group share same ID
     );
     rb_ary_push(ctx->merged_rules, new_rule);
 
@@ -658,14 +659,63 @@ static int flatten_selector_group_callback(VALUE selector, VALUE group_indices, 
  * Takes an array of rule indices that all share the same selector,
  * expands shorthands, applies cascade rules, and recreates shorthands.
  *
+ * @param out_selector_list_id Output parameter: set to selector_list_id if all rules share same ID, else Qnil
  * Returns: Array of merged Declaration structs
  */
-static VALUE flatten_rules_for_selector(VALUE rules_array, VALUE rule_indices, VALUE selector) {
+static VALUE flatten_rules_for_selector(VALUE rules_array, VALUE rule_indices, VALUE selector, VALUE *out_selector_list_id) {
     long num_rules_in_group = RARRAY_LEN(rule_indices);
     VALUE properties_hash = rb_hash_new();
 
     DEBUG_PRINTF("    [flatten_rules_for_selector] Merging %ld rules for selector '%s'\n",
                  num_rules_in_group, RSTRING_PTR(selector));
+
+    // Extract selector_list_id from rules - preserve if all rules share same ID
+    VALUE first_selector_list_id = Qnil;
+    int all_same_selector_list_id = 1;
+
+    DEBUG_PRINTF("    Checking if rules share same selector_list_id...\n");
+
+    for (long g = 0; g < num_rules_in_group; g++) {
+        long rule_idx = FIX2LONG(rb_ary_entry(rule_indices, g));
+        VALUE rule = RARRAY_AREF(rules_array, rule_idx);
+
+        // Skip AtRule objects - they don't have selector_list_id
+        if (rb_obj_is_kind_of(rule, cAtRule)) {
+            continue;
+        }
+
+        VALUE selector_list_id = rb_struct_aref(rule, INT2FIX(RULE_SELECTOR_LIST_ID));
+
+        if (NIL_P(selector_list_id)) {
+            DEBUG_PRINTF("      Rule %ld: has nil selector_list_id, can't preserve\n", g);
+            // If any rule has nil selector_list_id, can't preserve
+            all_same_selector_list_id = 0;
+            break;
+        }
+
+        if (g == 0 || NIL_P(first_selector_list_id)) {
+            first_selector_list_id = selector_list_id;
+            DEBUG_PRINTF("      Rule %ld: first selector_list_id=%ld\n", g, NUM2LONG(first_selector_list_id));
+        } else if (!rb_equal(first_selector_list_id, selector_list_id)) {
+            DEBUG_PRINTF("      Rule %ld: different selector_list_id=%ld (vs %ld), can't preserve\n",
+                         g, NUM2LONG(selector_list_id), NUM2LONG(first_selector_list_id));
+            // Different selector_list_ids - can't preserve
+            all_same_selector_list_id = 0;
+            break;
+        } else {
+            DEBUG_PRINTF("      Rule %ld: same selector_list_id=%ld\n", g, NUM2LONG(selector_list_id));
+        }
+    }
+
+    // Set output parameter: preserve selector_list_id only if all rules share same ID
+    if (out_selector_list_id) {
+        *out_selector_list_id = (all_same_selector_list_id && !NIL_P(first_selector_list_id)) ? first_selector_list_id : Qnil;
+        if (!NIL_P(*out_selector_list_id)) {
+            DEBUG_PRINTF("    -> Preserving selector_list_id=%ld for merged rule\n", NUM2LONG(*out_selector_list_id));
+        } else {
+            DEBUG_PRINTF("    -> NOT preserving selector_list_id (not all same)\n");
+        }
+    }
 
     // Process each rule in this selector group
     for (long g = 0; g < num_rules_in_group; g++) {
@@ -1016,6 +1066,174 @@ static VALUE flatten_rules_for_selector(VALUE rules_array, VALUE rule_indices, V
     return merged_decls;
 }
 
+/*
+ * Helper function: Check if two declaration arrays are equal
+ *
+ * Returns: true if declarations have same properties, values, and importance
+ */
+static int declarations_equal(VALUE decls1, VALUE decls2) {
+    long len1 = RARRAY_LEN(decls1);
+    long len2 = RARRAY_LEN(decls2);
+
+    DEBUG_PRINTF("      [declarations_equal] Comparing %ld vs %ld declarations\n", len1, len2);
+
+    if (len1 != len2) {
+        DEBUG_PRINTF("      -> Different lengths, NOT equal\n");
+        return 0;
+    }
+
+    // Compare each declaration (property, value, important must all match)
+    for (long i = 0; i < len1; i++) {
+        VALUE d1 = RARRAY_AREF(decls1, i);
+        VALUE d2 = RARRAY_AREF(decls2, i);
+
+        VALUE prop1 = rb_struct_aref(d1, INT2FIX(DECL_PROPERTY));
+        VALUE prop2 = rb_struct_aref(d2, INT2FIX(DECL_PROPERTY));
+        VALUE val1 = rb_struct_aref(d1, INT2FIX(DECL_VALUE));
+        VALUE val2 = rb_struct_aref(d2, INT2FIX(DECL_VALUE));
+        VALUE imp1 = rb_struct_aref(d1, INT2FIX(DECL_IMPORTANT));
+        VALUE imp2 = rb_struct_aref(d2, INT2FIX(DECL_IMPORTANT));
+
+        if (!rb_equal(prop1, prop2) || !rb_equal(val1, val2) || (RTEST(imp1) != RTEST(imp2))) {
+            DEBUG_PRINTF("      -> Decl %ld differs: %s:%s%s vs %s:%s%s\n",
+                         i,
+                         RSTRING_PTR(prop1), RSTRING_PTR(val1), RTEST(imp1) ? "!" : "",
+                         RSTRING_PTR(prop2), RSTRING_PTR(val2), RTEST(imp2) ? "!" : "");
+            // Protect VALUEs from GC after rb_equal() calls and before RSTRING_PTR usage above
+            RB_GC_GUARD(prop1);
+            RB_GC_GUARD(val1);
+            RB_GC_GUARD(prop2);
+            RB_GC_GUARD(val2);
+            return 0;
+        }
+    }
+
+    DEBUG_PRINTF("      -> All declarations match, equal\n");
+    return 1;
+}
+
+/*
+ * Update selector lists to remove diverged rules
+ *
+ * After flattening/cascade, rules that were in the same selector list may have
+ * different declarations. This function builds the selector_lists hash with only
+ * rules that still match, and clears selector_list_id for diverged rules.
+ *
+ * @param merged_rules Array of flattened rules (with new IDs assigned)
+ * @param selector_lists Empty hash to populate with list_id => Array of rule IDs
+ */
+static void update_selector_lists_for_divergence(VALUE merged_rules, VALUE selector_lists) {
+    DEBUG_PRINTF("\n=== update_selector_lists_for_divergence ===\n");
+
+    // Group merged rules by selector_list_id (skip rules with no list)
+    // NOTE: Using manual iteration instead of group_by to avoid Ruby method calls
+    VALUE rules_by_list = rb_hash_new();
+
+    long num_rules = RARRAY_LEN(merged_rules);
+    DEBUG_PRINTF("  Total merged rules: %ld\n", num_rules);
+
+    for (long i = 0; i < num_rules; i++) {
+        VALUE rule = RARRAY_AREF(merged_rules, i);
+
+        // Skip AtRule objects
+        if (rb_obj_is_kind_of(rule, cAtRule)) {
+            continue;
+        }
+
+        VALUE selector_list_id = rb_struct_aref(rule, INT2FIX(RULE_SELECTOR_LIST_ID));
+        VALUE selector = rb_struct_aref(rule, INT2FIX(RULE_SELECTOR));
+
+        if (NIL_P(selector_list_id)) {
+            DEBUG_PRINTF("  Rule %ld (%s): no selector_list_id\n", i, RSTRING_PTR(selector));
+            continue;
+        }
+
+        DEBUG_PRINTF("  Rule %ld (%s): selector_list_id=%ld\n",
+                     i, RSTRING_PTR(selector), NUM2LONG(selector_list_id));
+
+        VALUE group = rb_hash_aref(rules_by_list, selector_list_id);
+        if (NIL_P(group)) {
+            group = rb_ary_new();
+            rb_hash_aset(rules_by_list, selector_list_id, group);
+            DEBUG_PRINTF("    -> Created new group for list_id=%ld\n", NUM2LONG(selector_list_id));
+        }
+        rb_ary_push(group, rule);
+    }
+
+    // For each selector list, check if declarations still match
+    VALUE list_ids = rb_funcall(rules_by_list, rb_intern("keys"), 0);
+    long num_lists = RARRAY_LEN(list_ids);
+    DEBUG_PRINTF("  Found %ld selector list groups to check\n", num_lists);
+
+    for (long i = 0; i < num_lists; i++) {
+        VALUE list_id = RARRAY_AREF(list_ids, i);
+        VALUE rules_in_list = rb_hash_aref(rules_by_list, list_id);
+        long num_in_list = RARRAY_LEN(rules_in_list);
+
+        DEBUG_PRINTF("\n  Checking list_id=%ld: %ld rules\n", NUM2LONG(list_id), num_in_list);
+
+        // Skip if only one rule in list (nothing to compare)
+        if (num_in_list <= 1) {
+            DEBUG_PRINTF("    -> Only 1 rule, skipping\n");
+            continue;
+        }
+
+        // Get first rule as reference
+        VALUE reference_rule = RARRAY_AREF(rules_in_list, 0);
+        VALUE reference_selector = rb_struct_aref(reference_rule, INT2FIX(RULE_SELECTOR));
+        VALUE reference_decls = rb_struct_aref(reference_rule, INT2FIX(RULE_DECLARATIONS));
+
+        DEBUG_PRINTF("    Reference rule: selector=%s, %ld declarations\n",
+                     RSTRING_PTR(reference_selector), RARRAY_LEN(reference_decls));
+
+        // Find rules that still match (have identical declarations)
+        VALUE matching_rules = rb_ary_new();
+        rb_ary_push(matching_rules, reference_rule);
+
+        for (long j = 1; j < num_in_list; j++) {
+            VALUE rule = RARRAY_AREF(rules_in_list, j);
+            VALUE selector = rb_struct_aref(rule, INT2FIX(RULE_SELECTOR));
+            VALUE decls = rb_struct_aref(rule, INT2FIX(RULE_DECLARATIONS));
+
+            DEBUG_PRINTF("    Comparing rule %ld (selector=%s):\n", j, RSTRING_PTR(selector));
+
+            if (declarations_equal(reference_decls, decls)) {
+                DEBUG_PRINTF("      -> MATCHES reference, keeping in list\n");
+                rb_ary_push(matching_rules, rule);
+            } else {
+                DEBUG_PRINTF("      -> DIVERGED from reference, clearing selector_list_id\n");
+                // Clear selector_list_id for diverged rule
+                rb_struct_aset(rule, INT2FIX(RULE_SELECTOR_LIST_ID), Qnil);
+            }
+        }
+
+        // Only keep the selector list if at least 2 rules still match
+        long num_matching = RARRAY_LEN(matching_rules);
+        DEBUG_PRINTF("    Result: %ld/%ld rules still match\n", num_matching, num_in_list);
+
+        if (num_matching >= 2) {
+            // Build selector_lists hash with NEW rule IDs
+            VALUE rule_ids = rb_ary_new_capa(num_matching);
+            for (long j = 0; j < num_matching; j++) {
+                VALUE rule = RARRAY_AREF(matching_rules, j);
+                VALUE rule_id = rb_struct_aref(rule, INT2FIX(RULE_ID));
+                rb_ary_push(rule_ids, rule_id);
+            }
+            rb_hash_aset(selector_lists, list_id, rule_ids);
+            DEBUG_PRINTF("    -> Keeping selector list with %ld rules\n", num_matching);
+        } else {
+            DEBUG_PRINTF("    -> Only 1 rule left, clearing selector_list_id for it too\n");
+            // Clear selector_list_id for the last remaining rule too
+            for (long j = 0; j < num_matching; j++) {
+                VALUE rule = RARRAY_AREF(matching_rules, j);
+                rb_struct_aset(rule, INT2FIX(RULE_SELECTOR_LIST_ID), Qnil);
+            }
+        }
+    }
+
+    DEBUG_PRINTF("\n=== End divergence tracking: %ld selector lists preserved ===\n\n", RHASH_SIZE(selector_lists));
+}
+
 // Flatten CSS rules by applying cascade rules
 // Input: Stylesheet object or CSS string
 // Output: Stylesheet with flattened declarations (cascade applied)
@@ -1216,10 +1434,8 @@ VALUE cataract_flatten(VALUE self, VALUE input) {
         VALUE passthrough_sheet = rb_class_new_instance(0, NULL, cStylesheet);
         rb_ivar_set(passthrough_sheet, id_ivar_rules, passthrough_rules);
 
-        // Set empty @media_index
+        // Set empty @media_index (no media rules after flatten)
         VALUE media_idx = rb_hash_new();
-        VALUE all_ids = rb_ary_new();
-        rb_hash_aset(media_idx, ID2SYM(id_all), all_ids);
         rb_ivar_set(passthrough_sheet, id_ivar_media_index, media_idx);
 
         return passthrough_sheet;
@@ -1260,14 +1476,45 @@ VALUE cataract_flatten(VALUE self, VALUE input) {
 
         rb_ivar_set(merged_sheet, id_ivar_rules, merged_rules);
 
-        // Set @media_index with :all pointing to all rule IDs
-        VALUE media_idx = rb_hash_new();
-        VALUE all_ids = rb_ary_new();
-        for (int i = 0; i < rule_id_counter; i++) {
-            rb_ary_push(all_ids, INT2FIX(i));
+        // Handle selector list divergence: remove rules from selector lists if declarations no longer match
+        // This makes selector_list_id authoritative - if set, declarations MUST be identical
+        // Only process if selector_lists is enabled in the stylesheet's parser options
+        VALUE selector_lists = rb_hash_new();
+        int selector_lists_enabled = 0;
+
+        if (rb_obj_is_kind_of(input, cStylesheet)) {
+            VALUE parser_options = rb_ivar_get(input, rb_intern("@parser_options"));
+
+            if (!NIL_P(parser_options)) {
+                VALUE enabled_val = rb_hash_aref(parser_options, ID2SYM(rb_intern("selector_lists")));
+                selector_lists_enabled = RTEST(enabled_val);
+
+                if (selector_lists_enabled) {
+                    update_selector_lists_for_divergence(merged_rules, selector_lists);
+                } else {
+                    // Clear all selector_list_ids when feature is disabled
+                    for (long i = 0; i < rule_id_counter; i++) {
+                        VALUE rule = RARRAY_AREF(merged_rules, i);
+                        if (!rb_obj_is_kind_of(rule, cAtRule)) {
+                            rb_struct_aset(rule, INT2FIX(RULE_SELECTOR_LIST_ID), Qnil);
+                        }
+                    }
+                }
+            } else {
+                // Default behavior when parser_options is nil: assume enabled
+                selector_lists_enabled = 1;
+                update_selector_lists_for_divergence(merged_rules, selector_lists);
+            }
         }
-        rb_hash_aset(media_idx, ID2SYM(id_all), all_ids);
+
+        // Set @media_index to empty hash (no media rules after flatten)
+        // NOTE: Setting to empty hash instead of { all: [ids] } to match pure Ruby behavior
+        // and avoid wrapping output in @media all during serialization
+        VALUE media_idx = rb_hash_new();
         rb_ivar_set(merged_sheet, id_ivar_media_index, media_idx);
+
+        // Set @_selector_lists with divergence tracking
+        rb_ivar_set(merged_sheet, rb_intern("@_selector_lists"), selector_lists);
 
         return merged_sheet;
     }

--- a/ext/cataract/flatten.c
+++ b/ext/cataract/flatten.c
@@ -644,7 +644,8 @@ static int flatten_selector_group_callback(VALUE selector, VALUE group_indices, 
         merged_decls,
         Qnil,  // specificity
         Qnil,  // parent_rule_id
-        Qnil   // nesting_style
+        Qnil,  // nesting_style
+        Qnil   // selector_list_id
     );
     rb_ary_push(ctx->merged_rules, new_rule);
 
@@ -1732,7 +1733,8 @@ VALUE cataract_flatten(VALUE self, VALUE input) {
         merged_declarations,      // declarations
         Qnil,                     // specificity (not applicable)
         Qnil,                     // parent_rule_id (not nested)
-        Qnil                      // nesting_style (not nested)
+        Qnil,                     // nesting_style (not nested)
+        Qnil                      // selector_list_id
     );
 
     // Set @rules array with single merged rule (use cached ID)

--- a/lib/cataract/pure.rb
+++ b/lib/cataract/pure.rb
@@ -84,14 +84,16 @@ module Cataract
   #
   # @api private
   # @param css_string [String] CSS to parse
+  # @param parser_options [Hash] Parser configuration options
+  # @option parser_options [Boolean] :selector_lists (true) Track selector lists
   # @return [Hash] {
   #   rules: Array<Rule>,           # Flat array of Rule/AtRule structs
   #   _media_index: Hash,           # Symbol => Array of rule IDs
   #   charset: String|nil,          # @charset value if present
   #   _has_nesting: Boolean         # Whether any nested rules exist
   # }
-  def self._parse_css(css_string)
-    parser = Parser.new(css_string)
+  def self._parse_css(css_string, parser_options = {})
+    parser = Parser.new(css_string, parser_options: parser_options)
     parser.parse
   end
 

--- a/lib/cataract/pure/parser.rb
+++ b/lib/cataract/pure/parser.rb
@@ -693,16 +693,8 @@ module Cataract
 
         charset_value = byteslice_encoded(value_start, @pos - value_start)
         charset_value.strip!
-        # Remove quotes (byte-by-byte)
-        result = String.new
-        i = 0
-        len = charset_value.bytesize
-        while i < len
-          byte = charset_value.getbyte(i)
-          result << charset_value[i] unless byte == BYTE_DQUOTE || byte == BYTE_SQUOTE
-          i += 1
-        end
-        @charset = result
+        # Remove quotes
+        @charset = charset_value.delete('"\'')
 
         @pos += 1 if peek_byte == BYTE_SEMICOLON # consume semicolon
         return

--- a/lib/cataract/pure/parser.rb
+++ b/lib/cataract/pure/parser.rb
@@ -286,7 +286,7 @@ module Cataract
         old_pos = @pos
         skip_whitespace
         skip_comment
-      end until @pos == old_pos # No progress made
+      end until @pos == old_pos # No progress made # rubocop:disable Lint/Loop
     end
 
     # Find matching closing brace

--- a/lib/cataract/pure/parser.rb
+++ b/lib/cataract/pure/parser.rb
@@ -184,11 +184,20 @@ module Cataract
 
             rule_id = @rule_id_counter
 
+            # Dup declarations for each rule in a selector list to avoid shared state
+            # (principle of least surprise - modifying one rule shouldn't affect others)
+            # Must deep dup: both the array and the Declaration objects inside
+            rule_declarations = if list_id
+                                  declarations.map { |d| Declaration.new(d.property, d.value, d.important) }
+                                else
+                                  declarations
+                                end
+
             # Create Rule struct (with selector_list_id as 7th parameter)
             rule = Rule.new(
               rule_id,             # id
               individual_selector, # selector
-              declarations,        # declarations
+              rule_declarations,   # declarations
               nil,                 # specificity (calculated lazily)
               nil,                 # parent_rule_id
               nil,                 # nesting_style

--- a/lib/cataract/pure/parser.rb
+++ b/lib/cataract/pure/parser.rb
@@ -113,7 +113,9 @@ module Cataract
         # Must be a selector-based rule
         selector = parse_selector
 
-        next if selector.nil? || selector.empty?
+        if selector.nil? || selector.empty?
+          next
+        end
 
         # Find the block boundaries
         decl_start = @pos # Should be right after the {
@@ -323,6 +325,7 @@ module Cataract
 
       # Trim whitespace from selector (in-place to avoid allocation)
       selector_text.strip!
+      selector_text
     end
 
     # Parse mixed block containing declarations AND nested selectors/at-rules
@@ -622,7 +625,7 @@ module Cataract
           end
 
           # Check for 'important' (9 chars)
-          if i >= 8 && value[(i - 8)..i] == 'important'
+          if i >= 8 && value[(i - 8), 9] == 'important'
             i -= 9
             # Skip whitespace before 'important'
             while i >= 0

--- a/lib/cataract/pure/serializer.rb
+++ b/lib/cataract/pure/serializer.rb
@@ -82,81 +82,20 @@ module Cataract
     result
   end
 
-  # Helper: serialize rules without nesting support
+  # Helper: serialize rules without nesting support (compact format)
   def self.stylesheet_to_s_original(rules, media_index, result, selector_lists)
-    # Check if selector list grouping is enabled (non-empty hash means enabled)
-    grouping_enabled = selector_lists && !selector_lists.empty?
-
-    # Build rule_id => media_symbol map
-    rule_to_media = {}
-    media_index.each do |media_sym, rule_ids|
-      rule_ids.each do |rule_id|
-        rule_to_media[rule_id] = media_sym
-      end
-    end
-
-    # Iterate through rules in insertion order, grouping consecutive media queries
-    current_media = nil
-    in_media_block = false
-
-    # Track processed rules to avoid duplicates when grouping
-    processed_rule_ids = {}
-
-    rules.each do |rule|
-      # Skip if already processed (when grouped)
-      next if processed_rule_ids[rule.id]
-
-      rule_media = rule_to_media[rule.id]
-
-      if rule_media.nil?
-        # Not in any media query - close any open media block first
-        if in_media_block
-          result << "}\n"
-          in_media_block = false
-          current_media = nil
-        end
-      else
-        # This rule is in a media query
-        # Check if media query changed from previous rule
-        if current_media.nil? || current_media != rule_media
-          # Close previous media block if open
-          if in_media_block
-            result << "}\n"
-          end
-
-          # Open new media block
-          current_media = rule_media
-          result << "@media #{current_media} {\n"
-          in_media_block = true
-        end
-      end
-
-      # Try to group with other rules from same selector list
-      if grouping_enabled && rule.is_a?(Rule) && rule.selector_list_id
-        selectors = find_groupable_selectors(
-          rule: rule,
-          rules: rules,
-          selector_lists: selector_lists,
-          processed_rule_ids: processed_rule_ids,
-          rule_to_media: rule_to_media,
-          current_media: current_media
-        )
-        # Serialize with grouped selectors (compact format)
-        result << selectors.join(', ') << ' { '
-        serialize_declarations(result, rule.declarations)
-        result << " }\n"
-      else
-        serialize_rule(result, rule)
-        processed_rule_ids[rule.id] = true
-      end
-    end
-
-    # Close final media block if still open
-    if in_media_block
-      result << "}\n"
-    end
-
-    result
+    _serialize_stylesheet_with_grouping(
+      rules: rules,
+      media_index: media_index,
+      result: result,
+      selector_lists: selector_lists,
+      opening_brace: ' { ',
+      closing_brace: " }\n",
+      media_indent: '',
+      decl_indent_base: nil,
+      decl_indent_media: nil,
+      add_blank_lines: false
+    )
   end
 
   # Helper: serialize a rule with its nested children
@@ -295,6 +234,143 @@ module Cataract
 
     matching_selectors
   end
+
+  # Private shared implementation for stylesheet serialization with optional selector list grouping
+  # All formatting behavior controlled by kwargs to avoid mode flags and if/else branches
+  def self._serialize_stylesheet_with_grouping(
+    rules:,
+    media_index:,
+    result:,
+    selector_lists:,
+    opening_brace:,      # ' { ' (compact) vs " {\n" (formatted)
+    closing_brace:,      # " }\n" (compact) vs "}\n" (formatted)
+    media_indent:,       # '' (compact) vs '  ' (formatted)
+    decl_indent_base:,   # nil (compact) vs '  ' (formatted base rules)
+    decl_indent_media:,  # nil (compact) vs '    ' (formatted media rules)
+    add_blank_lines:     # false (compact) vs true (formatted)
+  )
+    grouping_enabled = selector_lists && !selector_lists.empty?
+
+    # Build rule_id => media_symbol map
+    rule_to_media = {}
+    media_index.each do |media_sym, rule_ids|
+      rule_ids.each do |rule_id|
+        rule_to_media[rule_id] = media_sym
+      end
+    end
+
+    # Track processed rules to avoid duplicates when grouping
+    processed_rule_ids = {}
+
+    # Iterate through rules in insertion order, grouping consecutive media queries
+    current_media = nil
+    in_media_block = false
+    rule_index = 0
+
+    rules.each do |rule|
+      # Skip if already processed (when grouped)
+      next if processed_rule_ids[rule.id]
+
+      rule_media = rule_to_media[rule.id]
+      is_first_rule = (rule_index == 0)
+
+      if rule_media.nil?
+        # Not in any media query - close any open media block first
+        if in_media_block
+          result << "}\n"
+          in_media_block = false
+          current_media = nil
+        end
+
+        # Add blank line prefix for non-first rules (formatted only)
+        result << "\n" if add_blank_lines && !is_first_rule
+
+        # Try to group with other rules from same selector list
+        if grouping_enabled && rule.is_a?(Rule) && rule.selector_list_id
+          selectors = find_groupable_selectors(
+            rule: rule,
+            rules: rules,
+            selector_lists: selector_lists,
+            processed_rule_ids: processed_rule_ids,
+            rule_to_media: rule_to_media,
+            current_media: rule_media
+          )
+
+          # Serialize with grouped selectors
+          result << selectors.join(', ') << opening_brace
+          if decl_indent_base
+            serialize_declarations_formatted(result, rule.declarations, decl_indent_base)
+          else
+            serialize_declarations(result, rule.declarations)
+          end
+          result << closing_brace
+        else
+          # Serialize individual rule
+          if decl_indent_base
+            serialize_rule_formatted(result, rule, '', true)
+          else
+            serialize_rule(result, rule)
+          end
+          processed_rule_ids[rule.id] = true
+        end
+      else
+        # This rule is in a media query
+        if current_media.nil? || current_media != rule_media
+          # Close previous media block if open
+          if in_media_block
+            result << "}\n"
+          end
+
+          # Add blank line prefix for non-first rules (formatted only)
+          result << "\n" if add_blank_lines && !is_first_rule
+
+          # Open new media block
+          current_media = rule_media
+          result << "@media #{current_media} {\n"
+          in_media_block = true
+        end
+
+        # Try to group with other rules from same selector list
+        if grouping_enabled && rule.is_a?(Rule) && rule.selector_list_id
+          selectors = find_groupable_selectors(
+            rule: rule,
+            rules: rules,
+            selector_lists: selector_lists,
+            processed_rule_ids: processed_rule_ids,
+            rule_to_media: rule_to_media,
+            current_media: rule_media
+          )
+
+          # Serialize with grouped selectors (with media indent)
+          result << media_indent << selectors.join(', ') << opening_brace
+          if decl_indent_media
+            serialize_declarations_formatted(result, rule.declarations, decl_indent_media)
+          else
+            serialize_declarations(result, rule.declarations)
+          end
+          result << media_indent << closing_brace
+        else
+          # Serialize individual rule inside media block
+          if decl_indent_media
+            serialize_rule_formatted(result, rule, media_indent, true)
+          else
+            serialize_rule(result, rule)
+          end
+          processed_rule_ids[rule.id] = true
+        end
+      end
+
+      rule_index += 1
+    end
+
+    # Close final media block if still open
+    if in_media_block
+      result << "}\n"
+    end
+
+    result
+  end
+  private_class_method :_serialize_stylesheet_with_grouping
 
   # Helper: check if two declaration arrays are equal
   def self.declarations_equal?(decls1, decls2)
@@ -459,70 +535,18 @@ module Cataract
 
   # Helper: formatted serialization without nesting support
   def self.stylesheet_to_formatted_s_original(rules, media_index, result, selector_lists)
-    # TODO: Phase 2 - implement selector list grouping for formatted output
-    # For now, just ignore selector_lists parameter
-
-    # Build rule_id => media_symbol map
-    rule_to_media = {}
-    media_index.each do |media_sym, rule_ids|
-      rule_ids.each do |rule_id|
-        rule_to_media[rule_id] = media_sym
-      end
-    end
-
-    # Iterate through rules, grouping consecutive media queries
-    current_media = nil
-    in_media_block = false
-    rule_index = 0
-
-    rules.each do |rule|
-      rule_media = rule_to_media[rule.id]
-      is_first_rule = (rule_index == 0)
-
-      if rule_media.nil?
-        # Not in any media query - close any open media block first
-        if in_media_block
-          result << "}\n"
-          in_media_block = false
-          current_media = nil
-        end
-
-        # Add blank line prefix for non-first rules
-        result << "\n" unless is_first_rule
-
-        # Output rule with no indentation (always single newline suffix)
-        serialize_rule_formatted(result, rule, '', true)
-      else
-        # This rule is in a media query
-        if current_media.nil? || current_media != rule_media
-          # Close previous media block if open
-          if in_media_block
-            result << "}\n"
-          end
-
-          # Add blank line prefix for non-first rules
-          result << "\n" unless is_first_rule
-
-          # Open new media block
-          current_media = rule_media
-          result << "@media #{current_media} {\n"
-          in_media_block = true
-        end
-
-        # Serialize rule inside media block with 2-space indentation
-        # Rules inside media blocks always get single newline (is_last=true)
-        serialize_rule_formatted(result, rule, '  ', true)
-      end
-
-      rule_index += 1
-    end
-
-    # Close final media block if still open
-    if in_media_block
-      result << "}\n"
-    end
-
-    result
+    _serialize_stylesheet_with_grouping(
+      rules: rules,
+      media_index: media_index,
+      result: result,
+      selector_lists: selector_lists,
+      opening_brace: " {\n",
+      closing_brace: "}\n",
+      media_indent: '  ',
+      decl_indent_base: '  ',
+      decl_indent_media: '    ',
+      add_blank_lines: true
+    )
   end
 
   # Helper: serialize a rule with nested children (formatted)

--- a/lib/cataract/pure/serializer.rb
+++ b/lib/cataract/pure/serializer.rb
@@ -381,8 +381,9 @@ module Cataract
   # @param media_index [Hash] Media query symbol => array of rule IDs
   # @param charset [String, nil] @charset value
   # @param has_nesting [Boolean] Whether any nested rules exist
+  # @param selector_lists [Hash] Selector list ID => array of rule IDs (for grouping)
   # @return [String] Formatted CSS string
-  def self._stylesheet_to_formatted_s(rules, media_index, charset, has_nesting)
+  def self._stylesheet_to_formatted_s(rules, media_index, charset, has_nesting, selector_lists = {})
     result = +''
 
     # Add @charset if present
@@ -392,7 +393,7 @@ module Cataract
 
     # Fast path: no nesting - use simple algorithm
     unless has_nesting
-      return stylesheet_to_formatted_s_original(rules, media_index, result)
+      return stylesheet_to_formatted_s_original(rules, media_index, result, selector_lists)
     end
 
     # Build parent-child relationships
@@ -457,7 +458,10 @@ module Cataract
   end
 
   # Helper: formatted serialization without nesting support
-  def self.stylesheet_to_formatted_s_original(rules, media_index, result)
+  def self.stylesheet_to_formatted_s_original(rules, media_index, result, selector_lists)
+    # TODO: Phase 2 - implement selector list grouping for formatted output
+    # For now, just ignore selector_lists parameter
+
     # Build rule_id => media_symbol map
     rule_to_media = {}
     media_index.each do |media_sym, rule_ids|

--- a/lib/cataract/rule.rb
+++ b/lib/cataract/rule.rb
@@ -24,16 +24,44 @@ module Cataract
   # @attr [Integer, nil] specificity CSS specificity value (calculated lazily)
   # @attr [Integer, nil] parent_rule_id Parent rule ID for nested rules
   # @attr [Integer, nil] nesting_style 0=implicit, 1=explicit, nil=not nested
+  # @attr [Integer, nil] selector_list_id ID linking rules from same selector list (e.g., "h1, h2")
   Rule = Struct.new(
     :id,
     :selector,
     :declarations,
     :specificity,
     :parent_rule_id,
-    :nesting_style
+    :nesting_style,
+    :selector_list_id
   )
 
   class Rule
+    # Factory method for creating Rules with keyword arguments (for tests/readability).
+    # C code and hot paths should use positional arguments directly via Rule.new.
+    #
+    # @param id [Integer] The rule's position in the stylesheet
+    # @param selector [String] CSS selector
+    # @param declarations [Array<Declaration>] Array of declarations
+    # @param specificity [Integer, nil] Specificity value (nil to calculate lazily)
+    # @param parent_rule_id [Integer, nil] Parent rule ID for nested rules
+    # @param nesting_style [Integer, nil] Nesting style (0=implicit, 1=explicit, nil=not nested)
+    # @param selector_list_id [Integer, nil] Selector list ID for grouping
+    # @return [Rule] New rule instance
+    #
+    # @example Create a rule with keyword arguments
+    #   Rule.make(
+    #     id: 0,
+    #     selector: '.foo',
+    #     declarations: [Declaration.new('color', 'red', false)],
+    #     specificity: 10,
+    #     parent_rule_id: nil,
+    #     nesting_style: nil,
+    #     selector_list_id: nil
+    #   )
+    def self.make(id:, selector:, declarations:, specificity: nil, parent_rule_id: nil, nesting_style: nil, selector_list_id: nil)
+      new(id, selector, declarations, specificity, parent_rule_id, nesting_style, selector_list_id)
+    end
+
     # Silence warning about method redefinition. We redefine below to lazily calculate
     # specificity
     undef_method :specificity if method_defined?(:specificity)

--- a/lib/cataract/stylesheet.rb
+++ b/lib/cataract/stylesheet.rb
@@ -340,7 +340,7 @@ module Cataract
 
       # If :all is present, return everything (no filtering)
       if which_media_array.include?(:all)
-        Cataract._stylesheet_to_s(@rules, @_media_index, @charset, @_has_nesting || false)
+        Cataract._stylesheet_to_s(@rules, @_media_index, @charset, @_has_nesting || false, @_selector_lists)
       else
         # Collect all rule IDs that match the requested media types
         matching_rule_ids = []
@@ -364,7 +364,7 @@ module Cataract
 
         # C serialization with filtered data
         # Note: Filtered rules might still contain nesting, so pass the flag
-        Cataract._stylesheet_to_s(filtered_rules, filtered_media_index, @charset, @_has_nesting || false)
+        Cataract._stylesheet_to_s(filtered_rules, filtered_media_index, @charset, @_has_nesting || false, @_selector_lists)
       end
     end
     alias to_css to_s
@@ -397,7 +397,7 @@ module Cataract
 
       # If :all is present, return everything (no filtering)
       if which_media_array.include?(:all)
-        Cataract._stylesheet_to_formatted_s(@rules, @_media_index, @charset, @_has_nesting || false)
+        Cataract._stylesheet_to_formatted_s(@rules, @_media_index, @charset, @_has_nesting || false, @_selector_lists)
       else
         # Collect all rule IDs that match the requested media types
         matching_rule_ids = []
@@ -429,7 +429,7 @@ module Cataract
 
         # C serialization with filtered data
         # Note: Filtered rules might still contain nesting, so pass the flag
-        Cataract._stylesheet_to_formatted_s(filtered_rules, filtered_media_index, @charset, @_has_nesting || false)
+        Cataract._stylesheet_to_formatted_s(filtered_rules, filtered_media_index, @charset, @_has_nesting || false, @_selector_lists)
       end
     end
 

--- a/lib/cataract/stylesheet.rb
+++ b/lib/cataract/stylesheet.rb
@@ -43,14 +43,24 @@ module Cataract
     #   - :base_path [String] Base directory for relative imports
     # @option options [Boolean] :io_exceptions (true) Whether to raise exceptions
     #   on I/O errors (file not found, network errors, etc.)
+    # @option options [Hash] :parser ({}) Parser configuration options
+    #   - :selector_lists [Boolean] (true) Track selector lists for W3C-compliant serialization
     def initialize(options = {})
       @options = {
         import: false,
-        io_exceptions: true
+        io_exceptions: true,
+        parser: {}
       }.merge(options)
+
+      # Parser options with defaults (stored for passing to parser)
+      @parser_options = {
+        selector_lists: true
+      }.merge(@options[:parser] || {})
 
       @rules = [] # Flat array of Rule structs
       @_media_index = {} # Hash: Symbol => Array of rule IDs
+      @_selector_lists = {} # Hash: list_id => Array of rule IDs (for "h1, h2" grouping)
+      @_next_selector_list_id = 0 # Counter for selector list IDs
       @charset = nil
       @imports = [] # Array of ImportStatement objects
       @_has_nesting = nil # Set by parser (nil or boolean)
@@ -69,6 +79,9 @@ module Cataract
       @rules = source.instance_variable_get(:@rules).dup
       @imports = source.instance_variable_get(:@imports).dup
       @_media_index = source.instance_variable_get(:@_media_index).transform_values(&:dup)
+      @_selector_lists = source.instance_variable_get(:@_selector_lists).transform_values(&:dup)
+      @_next_selector_list_id = source.instance_variable_get(:@_next_selector_list_id)
+      @parser_options = source.instance_variable_get(:@parser_options).dup
       @selectors = nil # Clear memoized cache
       @_hash = nil # Clear cached hash
     end
@@ -629,12 +642,28 @@ module Cataract
       offset = @_last_rule_id || 0
 
       # Parse CSS first (this extracts @import statements into result[:imports])
-      result = Cataract._parse_css(css)
+      result = Cataract._parse_css(css, @parser_options)
+
+      # Merge selector_lists with offsetted IDs
+      # Must do this BEFORE updating rule IDs so we can update rule.selector_list_id
+      list_id_offset = @_next_selector_list_id
+      if result[:_selector_lists] && !result[:_selector_lists].empty?
+        result[:_selector_lists].each do |list_id, rule_ids|
+          new_list_id = list_id + list_id_offset
+          offsetted_rule_ids = rule_ids.map { |id| id + offset }
+          @_selector_lists[new_list_id] = offsetted_rule_ids
+        end
+        @_next_selector_list_id = list_id_offset + result[:_selector_lists].size
+      end
 
       # Merge rules with offsetted IDs
       new_rules = result[:rules]
       new_rules.each do |rule|
         rule.id += offset
+        # Update selector_list_id to point to offsetted list (only for Rule, not AtRule)
+        if rule.is_a?(Rule) && rule.selector_list_id
+          rule.selector_list_id += list_id_offset
+        end
         @rules << rule
       end
 

--- a/test/fixtures/benchmarks/parsing_sample.json
+++ b/test/fixtures/benchmarks/parsing_sample.json
@@ -27,8 +27,8 @@
   "timestamp": "2025-10-30T16:01:43-05:00",
   "results": [
     {
-      "name": "css_parser gem: CSS1",
-      "implementation": "css_parser",
+      "name": "pure_without_yjit: CSS1",
+      "implementation": "pure_without_yjit",
       "central_tendency": 6253.617340248006,
       "ips": 6253.617340248006,
       "error": 63,
@@ -38,7 +38,7 @@
       "cycles": 587
     },
     {
-      "name": "cataract: CSS1",
+      "name": "native: CSS1",
       "implementation": "native",
       "central_tendency": 67860.26856079814,
       "ips": 67860.26856079814,
@@ -49,8 +49,8 @@
       "cycles": 6684
     },
     {
-      "name": "css_parser gem: CSS2",
-      "implementation": "css_parser",
+      "name": "pure_without_yjit: CSS2",
+      "implementation": "pure_without_yjit",
       "central_tendency": 3446.4007088523126,
       "ips": 3446.4007088523126,
       "error": 33,
@@ -60,7 +60,7 @@
       "cycles": 343
     },
     {
-      "name": "cataract: CSS2",
+      "name": "native: CSS2",
       "implementation": "native",
       "central_tendency": 44357.90385806872,
       "ips": 44357.90385806872,

--- a/test/fixtures/benchmarks/yjit_sample.json
+++ b/test/fixtures/benchmarks/yjit_sample.json
@@ -18,7 +18,7 @@
   "timestamp": "2025-10-30T16:26:08-05:00",
   "results": [
     {
-      "name": "no YJIT: property access",
+      "name": "pure_without_yjit: property access",
       "implementation": "pure_without_yjit",
       "central_tendency": 221028.7628245108,
       "ips": 221028.7628245108,
@@ -29,7 +29,7 @@
       "cycles": 22022
     },
     {
-      "name": "no YJIT: declaration merging",
+      "name": "pure_without_yjit: declaration merging",
       "implementation": "pure_without_yjit",
       "central_tendency": 197740.30877444957,
       "ips": 197740.30877444957,
@@ -40,7 +40,7 @@
       "cycles": 19758
     },
     {
-      "name": "no YJIT: to_s generation",
+      "name": "pure_without_yjit: to_s generation",
       "implementation": "pure_without_yjit",
       "central_tendency": 238198.91579009045,
       "ips": 238198.91579009045,
@@ -51,7 +51,7 @@
       "cycles": 23843
     },
     {
-      "name": "no YJIT: parse + iterate",
+      "name": "pure_without_yjit: parse + iterate",
       "implementation": "pure_without_yjit",
       "central_tendency": 88790.95673136998,
       "ips": 88790.95673136998,
@@ -62,7 +62,7 @@
       "cycles": 8911
     },
     {
-      "name": "YJIT: property access",
+      "name": "pure_with_yjit: property access",
       "implementation": "pure_with_yjit",
       "central_tendency": 308619.3738644762,
       "ips": 308619.3738644762,
@@ -73,7 +73,7 @@
       "cycles": 30835
     },
     {
-      "name": "YJIT: declaration merging",
+      "name": "pure_with_yjit: declaration merging",
       "implementation": "pure_with_yjit",
       "central_tendency": 313642.9237746988,
       "ips": 313642.9237746988,
@@ -84,7 +84,7 @@
       "cycles": 31280
     },
     {
-      "name": "YJIT: to_s generation",
+      "name": "pure_with_yjit: to_s generation",
       "implementation": "pure_with_yjit",
       "central_tendency": 368418.7840873258,
       "ips": 368418.7840873258,
@@ -95,7 +95,7 @@
       "cycles": 35469
     },
     {
-      "name": "YJIT: parse + iterate",
+      "name": "pure_with_yjit: parse + iterate",
       "implementation": "pure_with_yjit",
       "central_tendency": 103771.21841984437,
       "ips": 103771.21841984437,

--- a/test/parser/test_at_rules.rb
+++ b/test/parser/test_at_rules.rb
@@ -295,11 +295,10 @@ class TestAtRules < Minitest::Test
     @sheet.add_block(css)
     dumped = @sheet.to_s
 
-    # Should have all closing braces
-    assert_includes dumped, '@keyframes fade'
-    assert_includes dumped, 'from'
-    assert_includes dumped, 'opacity: 0'
-    assert_includes dumped, 'opacity: 1'
+    # Verify exact round-trip serialization
+    expected = "@keyframes fade {\n  from { opacity: 0; }\n  to { opacity: 1; }\n}\n"
+
+    assert_equal expected, dumped
 
     # Count braces - should be balanced
     open_braces = dumped.count('{')

--- a/test/parser/test_css_nesting.rb
+++ b/test/parser/test_css_nesting.rb
@@ -729,7 +729,7 @@ class TestCssNesting < Minitest::Test
       Cataract::Stylesheet.parse(css)
     end
 
-    assert_match(/CSS nesting too deep.*exceeded maximum depth of 10/i, error.message)
+    assert_equal 'CSS nesting too deep: exceeded maximum depth of 10', error.message
   end
 
   # Test depth error with @media nesting
@@ -741,7 +741,7 @@ class TestCssNesting < Minitest::Test
       Cataract::Stylesheet.parse(css)
     end
 
-    assert_match(/CSS nesting too deep.*exceeded maximum depth of 10/i, error.message)
+    assert_equal 'CSS nesting too deep: exceeded maximum depth of 10', error.message
   end
 
   # Test that depth error doesn't trigger at exactly max depth
@@ -1114,7 +1114,7 @@ class TestCssNesting < Minitest::Test
 
     assert_equal :'(orientation: landscape)', landscape_media
     # Combined media query should be: (orientation: landscape) and (min-width > 1024px)
-    assert_match(/orientation.*landscape.*min-width.*1024px/, nested_media.to_s)
+    assert_equal :'(orientation: landscape) and (min-width > 1024px)', nested_media
   end
 
   # W3C Spec Example: Mixed declarations order doesn't matter

--- a/test/parser/test_edge_cases.rb
+++ b/test/parser/test_edge_cases.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Edge case tests for CSS parser
+class TestEdgeCases < Minitest::Test
+  # ============================================================================
+  # Whitespace tolerance
+  # ============================================================================
+
+  def test_selector_list_without_space_before_brace
+    # Browsers accept this, so we should too
+    css = 'h1,h2,h3{ color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Should parse all 3 selectors
+    assert_equal 3, sheet.rules.size, 'Should parse all 3 selectors even without space before {'
+
+    # Check selectors are correct
+    assert_equal 'h1', sheet.rules[0].selector
+    assert_equal 'h2', sheet.rules[1].selector
+    assert_equal 'h3', sheet.rules[2].selector
+
+    # Check declarations
+    sheet.rules.each do |rule|
+      assert_equal 1, rule.declarations.size
+      assert_equal 'color', rule.declarations[0].property
+      assert_equal 'red', rule.declarations[0].value
+    end
+  end
+
+  def test_single_selector_without_space_before_brace
+    css = 'h1{ color: blue; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    assert_equal 1, sheet.rules.size
+    assert_equal 'h1', sheet.rules[0].selector
+    assert_equal 'color', sheet.rules[0].declarations[0].property
+    assert_equal 'blue', sheet.rules[0].declarations[0].value
+  end
+
+  def test_selector_list_with_inconsistent_spacing
+    # Mix of spaces and no spaces
+    css = 'h1,h2  ,  h3{ color: green; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    assert_equal 3, sheet.rules.size
+    assert_equal 'h1', sheet.rules[0].selector
+    assert_equal 'h2', sheet.rules[1].selector
+    assert_equal 'h3', sheet.rules[2].selector
+  end
+
+  def test_selector_list_no_space_after_comma
+    css = 'h1,h2,h3 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    assert_equal 3, sheet.rules.size
+  end
+
+  def test_class_selectors_no_space_before_brace
+    css = '.test1,.test2,.test3{ background: yellow; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    assert_equal 3, sheet.rules.size
+    assert_equal '.test1', sheet.rules[0].selector
+    assert_equal '.test2', sheet.rules[1].selector
+    assert_equal '.test3', sheet.rules[2].selector
+  end
+end

--- a/test/parser/test_selector_lists.rb
+++ b/test/parser/test_selector_lists.rb
@@ -1,0 +1,559 @@
+require_relative '../test_helper'
+
+class TestSelectorLists < Minitest::Test
+  include StylesheetTestHelper
+
+  # ============================================================================
+  # Basic Selector List Parsing
+  # ============================================================================
+
+  def test_simple_selector_list_creates_multiple_rules
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    # Should create 3 separate rules
+    assert_selector_count 3, sheet
+    assert_has_selector 'h1', sheet
+    assert_has_selector 'h2', sheet
+    assert_has_selector 'h3', sheet
+  end
+
+  def test_simple_selector_list_shares_same_list_id
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    rules = sheet.rules
+
+    assert_equal 3, rules.size
+
+    # All rules should have the same selector_list_id
+    list_ids = rules.map(&:selector_list_id).uniq
+
+    assert_equal 1, list_ids.size, 'All rules from same selector list should share selector_list_id'
+    refute_nil list_ids.first, 'Selector list ID should not be nil'
+  end
+
+  def test_simple_selector_list_tracked_in_selector_lists_hash
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    refute_empty selector_lists, 'Should have selector list entries'
+
+    # Should have one list entry
+    assert_equal 1, selector_lists.size
+
+    # Get the list ID and rule IDs
+    _, rule_ids = selector_lists.first
+
+    assert_equal 3, rule_ids.size, 'List should contain 3 rule IDs'
+
+    # Verify rule IDs match actual rules
+    assert_equal rule_ids.sort, sheet.rules.map(&:id).sort
+  end
+
+  def test_two_selector_list_creates_six_rules
+    css = 'h1, h2 { color: red; } h3, h4 { color: blue; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 4, sheet
+    assert_has_selector 'h1', sheet
+    assert_has_selector 'h2', sheet
+    assert_has_selector 'h3', sheet
+    assert_has_selector 'h4', sheet
+  end
+
+  def test_single_selector_has_nil_list_id
+    css = '.single { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    rule = sheet.rules.first
+
+    assert_nil rule.selector_list_id, 'Single selector should have nil selector_list_id'
+
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_empty selector_lists, 'Single selectors should not create list entries'
+  end
+
+  def test_mixed_single_and_list_selectors
+    css = '.single { color: red; } h1, h2 { color: blue; } .another { color: green; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 4, sheet
+
+    # Check which rules have list IDs
+    rules = sheet.rules
+    single1 = rules.find { |r| r.selector == '.single' }
+    h1 = rules.find { |r| r.selector == 'h1' }
+    h2 = rules.find { |r| r.selector == 'h2' }
+    single2 = rules.find { |r| r.selector == '.another' }
+
+    # Single selectors should have nil list_id
+    assert_nil single1.selector_list_id
+    assert_nil single2.selector_list_id
+
+    # List selectors should share same list_id
+    refute_nil h1.selector_list_id
+    assert_equal h1.selector_list_id, h2.selector_list_id
+
+    # Should have exactly one list entry
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_equal 1, selector_lists.size
+  end
+
+  # ============================================================================
+  # Complex Selector Lists
+  # ============================================================================
+
+  def test_compound_selector_list
+    css = 'h1.title, h2#main, div.container { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 3, sheet
+    assert_has_selector 'h1.title', sheet
+    assert_has_selector 'h2#main', sheet
+    assert_has_selector 'div.container', sheet
+
+    # All should share same list ID
+    list_ids = sheet.rules.map(&:selector_list_id).uniq
+
+    assert_equal 1, list_ids.size
+  end
+
+  def test_complex_selector_list
+    css = 'h1 > p, div .container, ul li + li { margin: 10px; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 3, sheet
+    assert_has_selector 'h1 > p', sheet
+    assert_has_selector 'div .container', sheet
+    assert_has_selector 'ul li + li', sheet
+
+    # All should share same list ID
+    list_ids = sheet.rules.map(&:selector_list_id).uniq
+
+    assert_equal 1, list_ids.size
+  end
+
+  def test_selector_list_with_whitespace
+    css = 'h1  ,  h2  ,  h3 { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 3, sheet
+    # Selectors should be trimmed
+    assert_has_selector 'h1', sheet
+    assert_has_selector 'h2', sheet
+    assert_has_selector 'h3', sheet
+  end
+
+  def test_selector_list_with_pseudo_classes
+    css = 'a:hover, a:focus, a:active { color: blue; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 3, sheet
+    assert_has_selector 'a:hover', sheet
+    assert_has_selector 'a:focus', sheet
+    assert_has_selector 'a:active', sheet
+
+    list_ids = sheet.rules.map(&:selector_list_id).uniq
+
+    assert_equal 1, list_ids.size
+  end
+
+  def test_selector_list_with_attribute_selectors
+    css = '[type="text"], [type="email"], [type="password"] { border: 1px solid gray; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 3, sheet
+    assert_has_selector '[type="text"]', sheet
+    assert_has_selector '[type="email"]', sheet
+    assert_has_selector '[type="password"]', sheet
+  end
+
+  # ============================================================================
+  # Multiple Independent Selector Lists
+  # ============================================================================
+
+  def test_multiple_independent_selector_lists
+    css = 'h1, h2 { color: red; } p, div { color: blue; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 4, sheet
+
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_equal 2, selector_lists.size, 'Should have two independent selector lists'
+
+    # Get rules for each list
+    h1 = sheet.rules.find { |r| r.selector == 'h1' }
+    h2 = sheet.rules.find { |r| r.selector == 'h2' }
+    p_rule = sheet.rules.find { |r| r.selector == 'p' }
+    div_rule = sheet.rules.find { |r| r.selector == 'div' }
+
+    # First list
+    assert_equal h1.selector_list_id, h2.selector_list_id
+    # Second list
+    assert_equal p_rule.selector_list_id, div_rule.selector_list_id
+    # Different lists
+    refute_equal h1.selector_list_id, p_rule.selector_list_id
+  end
+
+  def test_three_selector_lists
+    css = 'h1, h2 { color: red; } h3, h4 { color: blue; } h5, h6 { color: green; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 6, sheet
+
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_equal 3, selector_lists.size, 'Should have three independent selector lists'
+
+    # Each list should have 2 rules
+    selector_lists.each_value do |rule_ids|
+      assert_equal 2, rule_ids.size
+    end
+  end
+
+  # ============================================================================
+  # Declarations Consistency
+  # ============================================================================
+
+  def test_selector_list_rules_share_same_declarations
+    css = 'h1, h2, h3 { color: red; margin: 10px; }'
+    sheet = Cataract.parse_css(css)
+
+    rules = sheet.rules
+
+    assert_equal 3, rules.size
+
+    # All rules should have identical declarations
+    rules.each do |rule|
+      assert_has_property({ color: 'red' }, rule)
+      assert_has_property({ margin: '10px' }, rule)
+      assert_equal 2, rule.declarations.size
+    end
+  end
+
+  def test_selector_list_with_important_declarations
+    css = 'h1, h2 { color: red !important; }'
+    sheet = Cataract.parse_css(css)
+
+    rules = sheet.rules
+
+    assert_equal 2, rules.size
+
+    rules.each do |rule|
+      assert_has_property({ color: 'red !important' }, rule)
+    end
+  end
+
+  # ============================================================================
+  # Edge Cases
+  # ============================================================================
+
+  def test_empty_selector_list_ignored
+    # Leading/trailing commas should be handled gracefully
+    css = 'h1 { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 1, sheet
+    assert_nil sheet.rules.first.selector_list_id
+  end
+
+  def test_selector_list_with_newlines
+    css = <<~CSS
+      h1,
+      h2,
+      h3 {
+        color: red;
+      }
+    CSS
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 3, sheet
+    list_ids = sheet.rules.map(&:selector_list_id).uniq
+
+    assert_equal 1, list_ids.size
+  end
+
+  def test_very_long_selector_list
+    # Test with many selectors in one list
+    selectors = (1..20).map { |i| ".class-#{i}" }.join(', ')
+    css = "#{selectors} { color: red; }"
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 20, sheet
+
+    # All should share same list ID
+    list_ids = sheet.rules.map(&:selector_list_id).uniq
+
+    assert_equal 1, list_ids.size
+
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_equal 1, selector_lists.size
+    _list_id, rule_ids = selector_lists.first
+
+    assert_equal 20, rule_ids.size
+  end
+
+  def test_selector_list_id_counter_increments
+    css = 'h1, h2 { color: red; } h3, h4 { color: blue; }'
+    sheet = Cataract.parse_css(css)
+
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+    list_ids = selector_lists.keys.sort
+
+    # Should have list IDs 0 and 1
+    assert_equal [0, 1], list_ids
+  end
+
+  def test_selector_list_preserves_rule_order
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    # Rules should appear in order: h1, h2, h3
+    selectors = sheet.rules.map(&:selector)
+
+    assert_equal %w[h1 h2 h3], selectors
+  end
+
+  # ============================================================================
+  # Media Queries with Selector Lists
+  # ============================================================================
+
+  def test_selector_list_in_media_query
+    css = '@media screen { h1, h2 { color: red; } }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 2, sheet
+
+    h1 = sheet.rules.find { |r| r.selector == 'h1' }
+    h2 = sheet.rules.find { |r| r.selector == 'h2' }
+
+    # Should share same list ID
+    assert_equal h1.selector_list_id, h2.selector_list_id
+
+    # Both should be in media query
+    assert_rule_in_media h1, :screen, sheet
+    assert_rule_in_media h2, :screen, sheet
+  end
+
+  def test_selector_list_with_nested_media
+    css = 'h1, h2 { color: red; } @media print { h3, h4 { color: blue; } }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 4, sheet
+
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_equal 2, selector_lists.size, 'Should have two selector lists (one in base, one in @media)'
+  end
+
+  # ============================================================================
+  # Integration with Existing Features
+  # ============================================================================
+
+  def test_selector_list_duplicates_work_with_dup
+    css = 'h1, h2 { color: red; }'
+    sheet1 = Cataract.parse_css(css)
+    sheet2 = sheet1.dup
+
+    # Should have same structure
+    assert_equal sheet1.rules.size, sheet2.rules.size
+
+    # Selector lists should be duplicated
+    selector_lists1 = sheet1.instance_variable_get(:@_selector_lists)
+    selector_lists2 = sheet2.instance_variable_get(:@_selector_lists)
+
+    assert_equal selector_lists1.keys, selector_lists2.keys
+    refute_same selector_lists1, selector_lists2, 'Should be a different object'
+  end
+
+  def test_selector_list_counter_tracks_correctly
+    css = 'h1, h2 { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    counter = sheet.instance_variable_get(:@_next_selector_list_id)
+
+    assert_equal 1, counter, 'Counter should be 1 after creating one list (IDs are 0-indexed)'
+  end
+
+  # ============================================================================
+  # Invalid Selectors - W3C Spec Compliance
+  # ============================================================================
+  #
+  # TODO: These tests are currently skipped because the parser is intentionally
+  # lenient and does not validate selector syntax. To make these tests pass,
+  # we need to implement selector validation as a parser option, which would
+  # mark invalid selectors in a separate hash and allow dropping entire selector
+  # lists when any selector is invalid per W3C spec.
+  #
+  # Future enhancement: Add parser option like `validate_selectors: true` that
+  # would enable strict CSS selector grammar validation.
+  # ============================================================================
+
+  def test_invalid_selector_at_start_drops_entire_list
+    skip 'Parser validation not yet implemented - see TODO above'
+
+    # Per W3C spec: if ANY selector in a list is invalid, drop the ENTIRE rule
+    css = '..invalid, h2, h3 { color: red; } h4 { color: blue; }'
+    sheet = Cataract.parse_css(css)
+
+    # Should only have h4 (the entire invalid list is dropped)
+    assert_selector_count 1, sheet
+    assert_has_selector 'h4', sheet
+    assert_no_selector_matches 'h2', sheet
+    assert_no_selector_matches 'h3', sheet
+
+    # No selector list should be created for the invalid group
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_empty selector_lists, 'Invalid selector list should not create entries'
+  end
+
+  def test_invalid_selector_in_middle_drops_entire_list
+    skip 'Parser validation not yet implemented - see TODO above'
+
+    css = 'h1, h2..foo, h3 { color: red; } p { color: blue; }'
+    sheet = Cataract.parse_css(css)
+
+    # Should only have p (the entire invalid list is dropped)
+    assert_selector_count 1, sheet
+    assert_has_selector 'p', sheet
+    assert_no_selector_matches 'h1', sheet
+    assert_no_selector_matches 'h3', sheet
+
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_empty selector_lists
+  end
+
+  def test_invalid_selector_at_end_drops_entire_list
+    skip 'Parser validation not yet implemented - see TODO above'
+
+    css = 'h1, h2, ..invalid { color: red; } div { color: blue; }'
+    sheet = Cataract.parse_css(css)
+
+    # Should only have div
+    assert_selector_count 1, sheet
+    assert_has_selector 'div', sheet
+    assert_no_selector_matches 'h1', sheet
+    assert_no_selector_matches 'h2', sheet
+  end
+
+  def test_multiple_invalid_selectors_in_list
+    skip 'Parser validation not yet implemented - see TODO above'
+
+    css = '..bad1, h2, ..bad2 { color: red; } span { color: blue; }'
+    sheet = Cataract.parse_css(css)
+
+    # Should only have span
+    assert_selector_count 1, sheet
+    assert_has_selector 'span', sheet
+    assert_no_selector_matches 'h2', sheet
+  end
+
+  def test_recovery_after_invalid_selector_list
+    skip 'Parser validation not yet implemented - see TODO above'
+
+    # Parser should recover and parse subsequent rules correctly
+    css = 'h1, ..invalid { color: red; } h2, h3 { color: blue; } h4 { color: green; }'
+    sheet = Cataract.parse_css(css)
+
+    # Should have h2, h3, h4 (first list dropped, others parsed)
+    assert_selector_count 3, sheet
+    assert_has_selector 'h2', sheet
+    assert_has_selector 'h3', sheet
+    assert_has_selector 'h4', sheet
+    assert_no_selector_matches 'h1', sheet
+
+    # Should have one selector list for h2, h3
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_equal 1, selector_lists.size
+  end
+
+  def test_all_valid_selectors_creates_list
+    # Sanity check: all valid selectors should work
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract.parse_css(css)
+
+    assert_selector_count 3, sheet
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_equal 1, selector_lists.size
+  end
+
+  def test_empty_selector_in_list_is_invalid
+    skip 'Parser validation not yet implemented - see TODO above'
+
+    # Empty selectors (e.g., "h1, , h3") should invalidate the list
+    css = 'h1, , h3 { color: red; } p { color: blue; }'
+    sheet = Cataract.parse_css(css)
+
+    # Should only have p
+    assert_selector_count 1, sheet
+    assert_has_selector 'p', sheet
+    assert_no_selector_matches 'h1', sheet
+    assert_no_selector_matches 'h3', sheet
+  end
+
+  # ============================================================================
+  # Parser Options - Disable Selector Lists
+  # ============================================================================
+
+  def test_selector_lists_disabled_does_not_populate_hash
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css, parser: { selector_lists: false })
+
+    # Should still create 3 rules
+    assert_selector_count 3, sheet
+
+    # But selector_lists hash should be empty
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    assert_empty selector_lists, 'Selector lists should be empty when disabled'
+
+    # All rules should have nil selector_list_id
+    sheet.rules.each do |rule|
+      assert_nil rule.selector_list_id, "Rule '#{rule.selector}' should have nil selector_list_id when disabled"
+    end
+
+    # Counter should not increment
+    counter = sheet.instance_variable_get(:@_next_selector_list_id)
+
+    assert_equal 0, counter, 'Counter should stay at 0 when selector lists disabled'
+  end
+
+  def test_selector_lists_enabled_by_default
+    css = 'h1, h2 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Parser options should have selector_lists: true by default
+    parser_options = sheet.instance_variable_get(:@parser_options)
+
+    assert parser_options[:selector_lists], 'selector_lists should be enabled by default'
+
+    # Should track selector lists
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    refute_empty selector_lists, 'Selector lists should be tracked by default'
+  end
+
+  def test_selector_lists_explicitly_enabled
+    css = 'h1, h2 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css, parser: { selector_lists: true })
+
+    # Should track selector lists
+    selector_lists = sheet.instance_variable_get(:@_selector_lists)
+
+    refute_empty selector_lists, 'Selector lists should be tracked when explicitly enabled'
+
+    # Rules should have selector_list_id
+    refute_nil sheet.rules.first.selector_list_id
+  end
+end

--- a/test/serialization/test_selector_list_formatted_serialization.rb
+++ b/test/serialization/test_selector_list_formatted_serialization.rb
@@ -1,0 +1,500 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Tests for selector list serialization with to_formatted_s
+#
+# Similar to test_selector_list_serialization.rb but for formatted output.
+# Rules with same selector_list_id and identical declarations should be grouped.
+class TestSelectorListFormattedSerialization < Minitest::Test
+  # ============================================================================
+  # Basic selector list serialization
+  # ============================================================================
+
+  def test_simple_selector_list_groups_on_serialization
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      h1, h2, h3 {
+        color: red;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_selector_list_preserves_original_order
+    css = '.alpha, .zeta, .beta { margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      .alpha, .zeta, .beta {
+        margin: 0;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_multiple_selector_lists_serialize_correctly
+    css = 'h1, h2 { color: red; } p, div { color: blue; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      h1, h2 {
+        color: red;
+      }
+
+      p, div {
+        color: blue;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  # ============================================================================
+  # Single selectors (no grouping)
+  # ============================================================================
+
+  def test_single_selector_unchanged
+    css = 'h1 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      h1 {
+        color: red;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_mixed_single_and_grouped_selectors
+    css = 'h1 { font-size: 24px; } h2, h3 { color: red; } p { margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      h1 {
+        font-size: 24px;
+      }
+
+      h2, h3 {
+        color: red;
+      }
+
+      p {
+        margin: 0;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  # ============================================================================
+  # Diverged declarations (no grouping when different)
+  # ============================================================================
+
+  def test_diverged_declarations_prevent_grouping
+    css = 'h1, h2 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Modify one rule's declarations
+    sheet.rules[0].declarations << Cataract::Declaration.new('font-size', '24px', false)
+
+    expected = <<~CSS
+      h1 {
+        color: red;
+        font-size: 24px;
+      }
+
+      h2 {
+        color: red;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_all_diverged_rules_serialize_separately
+    css = 'a, b, c { margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Modify each rule differently
+    sheet.rules[0].declarations << Cataract::Declaration.new('color', 'red', false)
+    sheet.rules[1].declarations << Cataract::Declaration.new('color', 'blue', false)
+    sheet.rules[2].declarations << Cataract::Declaration.new('color', 'green', false)
+
+    expected = <<~CSS
+      a {
+        margin: 0;
+        color: red;
+      }
+
+      b {
+        margin: 0;
+        color: blue;
+      }
+
+      c {
+        margin: 0;
+        color: green;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_partial_grouping_when_some_match
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Modify only h3
+    sheet.rules[2].declarations << Cataract::Declaration.new('font-size', '18px', false)
+
+    expected = <<~CSS
+      h1, h2 {
+        color: red;
+      }
+
+      h3 {
+        color: red;
+        font-size: 18px;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  # ============================================================================
+  # Complex selectors
+  # ============================================================================
+
+  def test_compound_selectors_in_list
+    css = 'div.foo, span.bar, a#baz { display: block; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      div.foo, span.bar, a#baz {
+        display: block;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_descendant_selectors_in_list
+    css = '.parent .child, .other .nested { padding: 10px; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      .parent .child, .other .nested {
+        padding: 10px;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_pseudo_class_selectors_in_list
+    css = 'a:hover, a:focus, a:active { text-decoration: underline; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      a:hover, a:focus, a:active {
+        text-decoration: underline;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_attribute_selectors_in_list
+    css = '[type="text"], [type="email"], [type="password"] { border: 1px solid gray; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      [type="text"], [type="email"], [type="password"] {
+        border: 1px solid gray;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_child_combinator_selectors_in_list
+    css = 'div > p, span > a { font-weight: bold; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      div > p, span > a {
+        font-weight: bold;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_adjacent_sibling_combinator_in_list
+    css = 'h1 + p, h2 + p { margin-top: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      h1 + p, h2 + p {
+        margin-top: 0;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_general_sibling_combinator_in_list
+    css = 'h1 ~ p, h2 ~ p { color: gray; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      h1 ~ p, h2 ~ p {
+        color: gray;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  # ============================================================================
+  # Whitespace handling
+  # ============================================================================
+
+  def test_selector_list_with_newlines_normalizes
+    css = "h1,\nh2,\nh3 { color: red; }"
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      h1, h2, h3 {
+        color: red;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  # ============================================================================
+  # Media queries
+  # ============================================================================
+
+  def test_selector_list_in_media_query
+    css = '@media screen { h1, h2 { color: red; } }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      @media screen {
+        h1, h2 {
+          color: red;
+        }
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_selector_list_across_media_boundaries_no_grouping
+    css = '@media screen { h1 { color: red; } } @media print { h1 { color: red; } }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      @media screen {
+        h1 {
+          color: red;
+        }
+      }
+
+      @media print {
+        h1 {
+          color: red;
+        }
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  # ============================================================================
+  # Important declarations
+  # ============================================================================
+
+  def test_selector_list_with_important_declarations
+    css = 'h1, h2 { color: red !important; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      h1, h2 {
+        color: red !important;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_mixed_important_prevents_grouping
+    css = 'h1, h2 { color: red !important; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Remove !important from one rule
+    sheet.rules[1].declarations[0].important = false
+
+    expected = <<~CSS
+      h1 {
+        color: red !important;
+      }
+
+      h2 {
+        color: red;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  # ============================================================================
+  # Multiple declarations
+  # ============================================================================
+
+  def test_selector_list_with_multiple_declarations
+    css = 'h1, h2 { color: red; font-size: 24px; margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      h1, h2 {
+        color: red;
+        font-size: 24px;
+        margin: 0;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_declaration_order_must_match_for_grouping
+    css = 'h1, h2 { color: red; margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Reverse declaration order for h2
+    sheet.rules[1].declarations.reverse!
+
+    expected = <<~CSS
+      h1 {
+        color: red;
+        margin: 0;
+      }
+
+      h2 {
+        margin: 0;
+        color: red;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  # ============================================================================
+  # Round-trip tests
+  # ============================================================================
+
+  def test_selector_list_round_trip
+    css = <<~CSS
+      h1, h2, h3 {
+        color: red;
+      }
+    CSS
+
+    sheet = Cataract::Stylesheet.parse(css)
+    serialized = sheet.to_formatted_s
+
+    # Parse the serialized output
+    sheet2 = Cataract::Stylesheet.parse(serialized)
+
+    # Should have same number of rules
+    assert_equal sheet.rules.size, sheet2.rules.size
+
+    # Should serialize identically
+    assert_equal serialized, sheet2.to_formatted_s
+  end
+
+  def test_complex_stylesheet_round_trip
+    css = <<~CSS
+      h1, h2 {
+        color: red;
+      }
+
+      .foo {
+        margin: 0;
+      }
+
+      p, div, span {
+        padding: 10px;
+      }
+
+      a:hover, a:focus {
+        text-decoration: underline;
+      }
+    CSS
+
+    sheet = Cataract::Stylesheet.parse(css)
+    serialized = sheet.to_formatted_s
+    sheet2 = Cataract::Stylesheet.parse(serialized)
+
+    assert_equal serialized, sheet2.to_formatted_s
+  end
+
+  # ============================================================================
+  # Edge cases
+  # ============================================================================
+
+  def test_empty_selector_list_not_serialized
+    css = 'h1, h2 { color: red; } p { margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Remove first two rules (the h1, h2 group)
+    sheet.instance_variable_get(:@rules).shift(2)
+
+    expected = <<~CSS
+      p {
+        margin: 0;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_single_rule_from_selector_list_no_grouping
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Remove h2 and h3
+    sheet.instance_variable_get(:@rules).delete_at(2)
+    sheet.instance_variable_get(:@rules).delete_at(1)
+
+    expected = <<~CSS
+      h1 {
+        color: red;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+
+  def test_very_long_selector_list
+    selectors = (1..20).map { |i| ".class-#{i}" }.join(', ')
+    css = "#{selectors} { display: block; }"
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = <<~CSS
+      #{selectors} {
+        display: block;
+      }
+    CSS
+
+    assert_equal expected, sheet.to_formatted_s
+  end
+end

--- a/test/serialization/test_selector_list_serialization.rb
+++ b/test/serialization/test_selector_list_serialization.rb
@@ -154,6 +154,33 @@ class TestSelectorListSerialization < Minitest::Test
     assert_equal expected, sheet.to_s
   end
 
+  def test_child_combinator_selectors_in_list
+    css = 'div > p, span > a { font-weight: bold; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "div > p, span > a { font-weight: bold; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_adjacent_sibling_combinator_in_list
+    css = 'h1 + p, h2 + p { margin-top: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "h1 + p, h2 + p { margin-top: 0; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_general_sibling_combinator_in_list
+    css = 'h1 ~ p, h2 ~ p { color: gray; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "h1 ~ p, h2 ~ p { color: gray; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
   # ============================================================================
   # Whitespace handling
   # ============================================================================

--- a/test/serialization/test_selector_list_serialization.rb
+++ b/test/serialization/test_selector_list_serialization.rb
@@ -1,0 +1,359 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+# Tests for selector list serialization (to_s)
+#
+# Current behavior: "h1, h2 { color: red; }" is serialized as separate rules:
+#   h1 { color: red; }
+#   h2 { color: red; }
+#
+# Expected behavior (Phase 2): Rules with same selector_list_id and identical declarations
+# should be grouped back together:
+#   h1, h2 { color: red; }
+class TestSelectorListSerialization < Minitest::Test
+  # ============================================================================
+  # Basic selector list serialization
+  # ============================================================================
+
+  def test_simple_selector_list_groups_on_serialization
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Should serialize back as grouped list
+    expected = "h1, h2, h3 { color: red; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_selector_list_preserves_original_order
+    css = '.alpha, .zeta, .beta { margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Should preserve original order, not alphabetize
+    expected = ".alpha, .zeta, .beta { margin: 0; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_multiple_selector_lists_serialize_correctly
+    css = 'h1, h2 { color: red; } p, div { color: blue; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "h1, h2 { color: red; }\np, div { color: blue; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  # ============================================================================
+  # Single selectors (no grouping)
+  # ============================================================================
+
+  def test_single_selector_unchanged
+    css = 'h1 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Single selectors should remain as-is
+    expected = "h1 { color: red; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_mixed_single_and_grouped_selectors
+    css = 'h1 { font-size: 24px; } h2, h3 { color: red; } p { margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "h1 { font-size: 24px; }\nh2, h3 { color: red; }\np { margin: 0; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  # ============================================================================
+  # Diverged declarations (no grouping when different)
+  # ============================================================================
+
+  def test_diverged_declarations_prevent_grouping
+    # Parse a selector list
+    css = 'h1, h2 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Modify one rule's declarations
+    sheet.rules[0].declarations << Cataract::Declaration.new('font-size', '24px', false)
+
+    # Should serialize as separate rules since declarations differ
+    expected = "h1 { color: red; font-size: 24px; }\nh2 { color: red; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_all_diverged_rules_serialize_separately
+    css = 'a, b, c { margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Modify each rule differently
+    sheet.rules[0].declarations << Cataract::Declaration.new('color', 'red', false)
+    sheet.rules[1].declarations << Cataract::Declaration.new('color', 'blue', false)
+    sheet.rules[2].declarations << Cataract::Declaration.new('color', 'green', false)
+
+    # All different, so serialize separately
+    expected = "a { margin: 0; color: red; }\nb { margin: 0; color: blue; }\nc { margin: 0; color: green; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_partial_grouping_when_some_match
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Modify only h3
+    sheet.rules[2].declarations << Cataract::Declaration.new('font-size', '18px', false)
+
+    # h1 and h2 should still group, h3 separate
+    expected = "h1, h2 { color: red; }\nh3 { color: red; font-size: 18px; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  # ============================================================================
+  # Complex selectors
+  # ============================================================================
+
+  def test_compound_selectors_in_list
+    css = 'div.foo, span.bar, a#baz { display: block; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "div.foo, span.bar, a#baz { display: block; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_descendant_selectors_in_list
+    css = '.parent .child, .other .nested { padding: 10px; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = ".parent .child, .other .nested { padding: 10px; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_pseudo_class_selectors_in_list
+    css = 'a:hover, a:focus, a:active { text-decoration: underline; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "a:hover, a:focus, a:active { text-decoration: underline; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_attribute_selectors_in_list
+    css = '[type="text"], [type="email"], [type="password"] { border: 1px solid gray; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "[type=\"text\"], [type=\"email\"], [type=\"password\"] { border: 1px solid gray; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  # ============================================================================
+  # Whitespace handling
+  # ============================================================================
+
+  def test_selector_list_normalizes_whitespace
+    skip 'Parser bug: pure Ruby parser requires space before { - see test/parser/test_edge_cases.rb'
+
+    # Input has inconsistent spacing
+    css = 'h1,h2  ,  h3{ color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Output should normalize to single space after comma
+    expected = "h1, h2, h3 { color: red; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_selector_list_with_newlines_normalizes
+    css = "h1,\nh2,\nh3 { color: red; }"
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Newlines should be normalized to comma-space
+    expected = "h1, h2, h3 { color: red; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  # ============================================================================
+  # Media queries
+  # ============================================================================
+
+  def test_selector_list_in_media_query
+    css = '@media screen { h1, h2 { color: red; } }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "@media screen {\nh1, h2 { color: red; }\n}\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_selector_list_across_media_boundaries_no_grouping
+    # Parse two separate rules in different media contexts
+    css = '@media screen { h1 { color: red; } } @media print { h1 { color: red; } }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Should NOT group across media boundaries even if declarations match
+    expected = "@media screen {\nh1 { color: red; }\n}\n@media print {\nh1 { color: red; }\n}\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  # ============================================================================
+  # Important declarations
+  # ============================================================================
+
+  def test_selector_list_with_important_declarations
+    css = 'h1, h2 { color: red !important; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "h1, h2 { color: red !important; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_mixed_important_prevents_grouping
+    css = 'h1, h2 { color: red !important; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Remove !important from one rule
+    sheet.rules[1].declarations[0].important = false
+
+    # Should serialize separately since one has !important and one doesn't
+    expected = "h1 { color: red !important; }\nh2 { color: red; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  # ============================================================================
+  # Multiple declarations
+  # ============================================================================
+
+  def test_selector_list_with_multiple_declarations
+    css = 'h1, h2 { color: red; font-size: 24px; margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "h1, h2 { color: red; font-size: 24px; margin: 0; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_declaration_order_must_match_for_grouping
+    css = 'h1, h2 { color: red; margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Reverse declaration order for h2
+    sheet.rules[1].declarations.reverse!
+
+    # Should NOT group since declaration order differs
+    # (This depends on how we define "identical" - might allow reordering)
+    expected = "h1 { color: red; margin: 0; }\nh2 { margin: 0; color: red; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  # ============================================================================
+  # Round-trip tests
+  # ============================================================================
+
+  def test_selector_list_round_trip
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+    serialized = sheet.to_s
+
+    # Parse the serialized output
+    sheet2 = Cataract::Stylesheet.parse(serialized)
+
+    # Should have same number of rules
+    assert_equal sheet.rules.size, sheet2.rules.size
+
+    # Should serialize identically
+    assert_equal serialized, sheet2.to_s
+  end
+
+  def test_complex_stylesheet_round_trip
+    css = <<~CSS
+      h1, h2 { color: red; }
+      .foo { margin: 0; }
+      p, div, span { padding: 10px; }
+      a:hover, a:focus { text-decoration: underline; }
+    CSS
+
+    sheet = Cataract::Stylesheet.parse(css)
+    serialized = sheet.to_s
+    sheet2 = Cataract::Stylesheet.parse(serialized)
+
+    assert_equal serialized, sheet2.to_s
+  end
+
+  # ============================================================================
+  # Edge cases
+  # ============================================================================
+
+  def test_empty_selector_list_not_serialized
+    # Manually create a stylesheet and remove all rules from a selector list
+    css = 'h1, h2 { color: red; } p { margin: 0; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Remove first two rules (the h1, h2 group)
+    sheet.instance_variable_get(:@rules).shift(2)
+
+    # Should only serialize the remaining rule
+    expected = "p { margin: 0; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_single_rule_from_selector_list_no_grouping
+    css = 'h1, h2, h3 { color: red; }'
+    sheet = Cataract::Stylesheet.parse(css)
+
+    # Remove h2 and h3
+    sheet.instance_variable_get(:@rules).delete_at(2)
+    sheet.instance_variable_get(:@rules).delete_at(1)
+
+    # Single remaining rule should serialize without comma
+    expected = "h1 { color: red; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  def test_very_long_selector_list
+    selectors = (1..20).map { |i| ".class-#{i}" }.join(', ')
+    css = "#{selectors} { display: block; }"
+    sheet = Cataract::Stylesheet.parse(css)
+
+    expected = "#{selectors} { display: block; }\n"
+
+    assert_equal expected, sheet.to_s
+  end
+
+  # ============================================================================
+  # Interaction with flatten/cascade
+  # ============================================================================
+
+  def test_flatten_may_diverge_selector_list
+    skip 'Phase 3: Implement selector list grouping in serializer'
+
+    # Selector list where rules end up with different declarations after cascade
+    css = <<~CSS
+      h1, h2 { color: red; }
+      h1 { font-size: 24px; }
+      h2 { font-size: 18px; }
+    CSS
+
+    sheet = Cataract::Stylesheet.parse(css)
+    flattened = Cataract.flatten(sheet)
+
+    # After flatten, h1 and h2 have different declarations, so serialize separately
+    expected = "h1 { color: red; font-size: 24px; }\nh2 { color: red; font-size: 18px; }\n"
+
+    assert_equal expected, flattened.to_s
+  end
+end

--- a/test/serialization/test_selector_list_serialization.rb
+++ b/test/serialization/test_selector_list_serialization.rb
@@ -186,8 +186,6 @@ class TestSelectorListSerialization < Minitest::Test
   # ============================================================================
 
   def test_selector_list_normalizes_whitespace
-    skip 'Parser bug: pure Ruby parser requires space before { - see test/parser/test_edge_cases.rb'
-
     # Input has inconsistent spacing
     css = 'h1,h2  ,  h3{ color: red; }'
     sheet = Cataract::Stylesheet.parse(css)

--- a/test/test_benchmark_doc_generator.rb
+++ b/test/test_benchmark_doc_generator.rb
@@ -55,7 +55,7 @@ class TestBenchmarkDocGenerator < Minitest::Test
 
     # Check parsing section exists
     assert_includes content, '## CSS Parsing'
-    assert_includes content, 'css_parser'
+    assert_includes content, 'Pure (no YJIT)'
     assert_includes content, 'faster'
   end
 

--- a/test/test_declarations.rb
+++ b/test/test_declarations.rb
@@ -249,8 +249,8 @@ class TestDeclarations < Minitest::Test
     # Should skip malformed declarations but keep valid ones
     valid_props = parent_rule.declarations.map(&:property)
 
-    assert_includes valid_props, 'color', 'Should parse valid color declaration'
-    assert_includes valid_props, 'margin', 'Should parse valid margin declaration'
+    assert_member valid_props, 'color', 'Should parse valid color declaration'
+    assert_member valid_props, 'margin', 'Should parse valid margin declaration'
     # Malformed ones should be skipped
     refute_includes valid_props, 'badprop', 'Should skip malformed badprop'
     refute_includes valid_props, 'anotherbad', 'Should skip malformed anotherbad'
@@ -276,9 +276,9 @@ class TestDeclarations < Minitest::Test
     # Should have valid declarations, skip malformed ones
     valid_props = at_rule.content.map(&:property)
 
-    assert_includes valid_props, 'font-family', 'Should parse valid font-family'
-    assert_includes valid_props, 'src', 'Should parse valid src'
-    assert_includes valid_props, 'font-weight', 'Should parse valid font-weight'
+    assert_member valid_props, 'font-family', 'Should parse valid font-family'
+    assert_member valid_props, 'src', 'Should parse valid src'
+    assert_member valid_props, 'font-weight', 'Should parse valid font-weight'
     # Malformed ones should be skipped
     refute_includes valid_props, 'badprop', 'Should skip malformed badprop'
     refute_includes valid_props, 'anotherbad', 'Should skip malformed anotherbad'

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -41,9 +41,9 @@ class TestEncoding < Minitest::Test
 
         # Verify the UTF-8 content is correct
         if decl.property == 'content'
-          assert_includes decl.value, '世界', 'UTF-8 characters should be preserved'
+          assert_equal '"Hello 世界"', decl.value, 'UTF-8 characters should be preserved'
         elsif decl.property == 'font-family'
-          assert_includes decl.value, 'ゴシック', 'UTF-8 characters should be preserved'
+          assert_equal '"ＭＳ ゴシック"', decl.value, 'UTF-8 characters should be preserved'
         end
       end
     end
@@ -57,9 +57,7 @@ class TestEncoding < Minitest::Test
     decl = sheet.rules.first.declarations.first
 
     assert_equal Encoding::UTF_8, decl.value.encoding
-    assert_includes decl.value, '👍'
-    assert_includes decl.value, '✨'
-    assert_includes decl.value, '🎉'
+    assert_equal '"👍 ✨ 🎉"', decl.value
   end
 
   def test_selectors_with_utf8_are_utf8
@@ -71,7 +69,7 @@ class TestEncoding < Minitest::Test
 
     assert_equal Encoding::UTF_8, rule.selector.encoding,
                  'Selector with UTF-8 should be UTF-8 encoded'
-    assert_includes rule.selector, '日本語'
+    assert_equal '.日本語', rule.selector
   end
 
   def test_ascii_selectors_are_utf8


### PR DESCRIPTION
# Selector List Tracking and Optimized Serialization

## Overview

This PR implements intelligent tracking and serialization of CSS selector lists (comma-separated selectors). When multiple selectors share the same declarations, Cataract now preserves their grouping through the parse → flatten → serialize cycle, producing cleaner, more maintainable CSS output.

## What Changed

### Selector List Tracking

The parser now tracks when selectors originate from the same comma-separated list:

```ruby
css = "h1, h2, h3 { color: red; }"
sheet = Cataract::Stylesheet.parse(css)

# All three rules remember they came from the same selector list
sheet.rules[0].selector_list_id  # => 0
sheet.rules[1].selector_list_id  # => 0
sheet.rules[2].selector_list_id  # => 0
```

### Intelligent Serialization

**Before (v0.2.1):**
```ruby
css = "h1, h2, h3 { color: red; margin: 0; }"
sheet = Cataract::Stylesheet.parse(css)
puts sheet.to_s
```
Output:
```css
h1 { color: red; margin: 0; }
h2 { color: red; margin: 0; }
h3 { color: red; margin: 0; }
```

**After (this PR):**
```ruby
css = "h1, h2, h3 { color: red; margin: 0; }"
sheet = Cataract::Stylesheet.parse(css)
puts sheet.to_s
```
Output:
```css
h1, h2, h3 { color: red; margin: 0; }
```

### Selector List Divergence During Cascade

When rules from the same selector list get different declarations during flatten/cascade, Cataract automatically detects the divergence and serializes them separately:

**Example:**
```ruby
css = <<~CSS
  h1, h2, h3 { color: red; }
  h3 { color: blue; }  /* h3 diverges from h1, h2 */
CSS

sheet = Cataract::Stylesheet.parse(css).flatten
puts sheet.to_s
```

Output:
```css
h1, h2 { color: red; }
h3 { color: blue; }
```

The cascade applied `color: blue` to `h3`, making its declarations different from `h1` and `h2`. Cataract detects this divergence and groups only the matching rules (`h1, h2`) while serializing the diverged rule (`h3`) separately.

### Formatted Serialization with Intelligent Line Wrapping

Selector lists now support configurable formatting with intelligent line wrapping:

```ruby
css = ".a, .b, .c, .d, .e, .f { margin: 0; }"
sheet = Cataract::Stylesheet.parse(css)

# Compact (default)
puts sheet.to_s
# => .a, .b, .c, .d, .e, .f { margin: 0; }

# Formatted with max line length
puts sheet.to_s(formatted: true, max_line_length: 40)
# Output:
# .a, .b, .c,
# .d, .e, .f {
#   margin: 0;
# }
```

The formatter:
- Wraps long selector lists intelligently at commas
- Preserves grouping of selectors with identical declarations
- Supports configurable indentation and line length limits
- Works with both flat rules and nested @media blocks

### Performance Optimizations

**Flatten hotpath optimizations:**
- Manual iteration instead of `select + group_by`: **50-60% faster** for selector list grouping
- Manual iteration instead of `group_by`: **10-25% faster** for selector grouping  
- Manual `concat` instead of `flat_map`: **5-10% faster** for shorthand expansion

**Benchmark improvements:**
- Added `Process.warmup` to benchmark harness for stable VM state before measurements

## Configuration

Selector list tracking is enabled by default. To disable:

```ruby
# Disable during parsing
sheet = Cataract::Stylesheet.parse(css, parser: { selector_lists: false })

# All selector_list_id values will be nil
sheet.rules.first.selector_list_id  # => nil
```

## Performance Impact

#### Parsing

Benchmarked parse-only overhead with selector list tracking on bootstrap.css (2,801 rules parsed, 831 assigned to selector lists):

**Pure Ruby**
- Parse time (enabled): 12.43 ms/iteration
- Parse time (disabled): 12.11 ms/iteration
- **Overhead**: ~3% (1.03x slower)

**C Extension**
- Parse time (enabled): 3.43 ms/iteration
- Parse time (disabled): 3.15 ms/iteration
- **Overhead**: ~9% (1.09x slower)

#### Flatten/Cascade

Benchmarked flatten overhead with selector list divergence tracking on bootstrap.css (2,648 rules after flatten):

**Pure Ruby**
- Parse time overhead: ~2.5% (1.22ms vs 1.19ms)
- Flatten time overhead: ~3.5% (1.56ms vs 1.51ms)
- **Overhead**: ~3.0% (2.78ms vs 2.70ms)

**C Extension**
- Parse time overhead: ~9% (0.33ms vs 0.30ms)
- Flatten time overhead: ~3.4% (0.64ms vs 0.62ms)
- **Overhead**: ~6.5% (0.98ms vs 0.92ms)
