### PR TITLE
Add ZJIT to the benchmark suite alongside interpreter/YJIT/native

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -178,5 +178,12 @@ Cataract/BanAssertIncludes:
     - 'test/color/**/*.rb'
     - 'test/test_benchmark_doc_generator.rb'
     - 'test/test_speedup_calculator.rb'
+    # Benchmark harness tests assert on generated markdown and on the wording
+    # of mismatch errors, not on parsed CSS.
+    - 'test/test_ruby_mode.rb'
+    - 'test/test_backend.rb'
+    - 'test/test_benchmark_implementation.rb'
+    - 'test/test_result_table.rb'
+    - 'test/test_benchmark_plumbing.rb'
     - 'test/test_parse_errors.rb'  # Parse error tests check error messages with assert_match
     - 'test/support/**/*'  # Support files define assert_contains which uses assert_includes internally

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -4,51 +4,55 @@
 
 # Performance Benchmarks
 
-Performance comparison between Cataract's C extension and pure Ruby implementations.
+Performance comparison between Cataract's C extension and pure Ruby implementations, including pure Ruby under the interpreter, YJIT, and ZJIT.
 
 ## Test Environment
 
-- **Ruby**: ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +YJIT +PRISM [arm64-darwin25]
+- **Ruby**: ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
 - **CPU**: Apple M1 Pro
 - **Memory**: 32GB
 - **OS**: macOS 26.3.1
-- **Generated**: 2026-07-08T10:35:16-05:00
+- **Generated**: 2026-07-30T11:56:59-05:00
 
 ## CSS Parsing
 
 Time to parse CSS into internal data structures
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
-|-----------|--------|----------------|-------------|
-| Small CSS (64 lines, 1.0KB) | 36.76K i/s | 3.33K i/s | 13.66K i/s |
-| Medium CSS with @media (139 lines, 1.6KB) | 29.98K i/s | 2.11K i/s | 8.98K i/s |
-| Selector lists (3500 lines, 62.5KB, 500 lists) | 447.4 i/s | 58.0 i/s | 219.8 i/s |
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|-----------|--------|----------------|-------------|-------------|
+| Small CSS (64 lines, 1.0KB) | 37.58K i/s | 3.33K i/s | 13.84K i/s | 7.56K i/s |
+| Medium CSS with @media (139 lines, 1.6KB) | 34.71K i/s | 2.11K i/s | 8.84K i/s | 4.86K i/s |
+| Selector lists (3500 lines, 62.5KB, 500 lists) | 435.4 i/s | 57.2 i/s | 214.8 i/s | 127.3 i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 13.03x faster (avg) |
-| Native vs Pure (YJIT) | 3.12x faster (avg) |
+| Native vs Pure (no YJIT) | 13.96x faster (avg) |
+| Native vs Pure (YJIT) | 3.34x faster (avg) |
+| Native vs Pure (ZJIT) | 5.99x faster (avg) |
 | YJIT impact on Pure Ruby | 4.15x faster (avg) |
+| ZJIT impact on Pure Ruby | 2.32x faster (avg) |
+| ZJIT vs YJIT | 1.79x slower (avg) |
 
 ### Parse Error Checking Overhead
 
 Parse error detection can be enabled with `raise_parse_errors: true`. This compares performance impact:
 
-| Configuration | Native | Pure (no YJIT) | Pure (YJIT) |
-|---------------|--------|----------------|-------------|
-| Medium CSS (139 lines) - no error checking | 33.57K i/s | 2.12K i/s | 9.08K i/s |
-| Medium CSS (139 lines) - with error checking | 33.09K i/s | 1.94K i/s | 8.19K i/s |
+| Configuration | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|---------------|--------|----------------|-------------|-------------|
+| Medium CSS (139 lines) - no error checking | 34.98K i/s | 2.11K i/s | 8.97K i/s | 4.85K i/s |
+| Medium CSS (139 lines) - with error checking | 34.33K i/s | 1.91K i/s | 8.08K i/s | 4.59K i/s |
 
 **Overhead Analysis:**
 
 
 | Implementation | Overhead |
 |----------------|----------|
-| Native | 1.5% slower |
-| Pure (no YJIT) | 9.2% slower |
-| Pure (YJIT) | 10.9% slower |
+| Native | 1.9% slower |
+| Pure (no YJIT) | 10.6% slower |
+| Pure (YJIT) | 11.1% slower |
+| Pure (ZJIT) | 5.7% slower |
 
 ---
 
@@ -56,21 +60,24 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
 Time to convert parsed CSS back to string format
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
-|-----------|--------|----------------|-------------|
-| to_s (Bootstrap - 191KB) | 1.05K i/s | 368.6 i/s | 555.6 i/s |
-| to_s (Compact utilities - 2.9KB) | 1.05K i/s | 368.6 i/s | 555.6 i/s |
-| to_formatted_s (Nested CSS - 1.3KB) | 156.05K i/s | 53.98K i/s | 90.18K i/s |
-| to_s with selector_lists (3.4KB) | 15.37K i/s | 7.71K i/s | 12.09K i/s |
-| Media filtering (Bootstrap print only) | 1.18K i/s | 547.1 i/s | 769.2 i/s |
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|-----------|--------|----------------|-------------|-------------|
+| to_s (Bootstrap - 191KB) | 1.05K i/s | 297.2 i/s | 489.0 i/s | 343.3 i/s |
+| to_s (Compact utilities - 2.9KB) | 1.05K i/s | 297.2 i/s | 489.0 i/s | 343.3 i/s |
+| to_formatted_s (Nested CSS - 1.3KB) | 175.44K i/s | 54.96K i/s | 88.31K i/s | 64.77K i/s |
+| to_s with selector_lists (3.4KB) | 15.9K i/s | 6.85K i/s | 10.84K i/s | 8.01K i/s |
+| Media filtering (Bootstrap print only) | 1.17K i/s | 470.2 i/s | 683.1 i/s | 553.6 i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 2.71x faster (avg) |
-| Native vs Pure (YJIT) | 1.75x faster (avg) |
-| YJIT impact on Pure Ruby | 1.55x faster (avg) |
+| Native vs Pure (no YJIT) | 3.32x faster (avg) |
+| Native vs Pure (YJIT) | 2.05x faster (avg) |
+| Native vs Pure (ZJIT) | 2.99x faster (avg) |
+| YJIT impact on Pure Ruby | 1.6x faster (avg) |
+| ZJIT impact on Pure Ruby | 1.13x faster (avg) |
+| ZJIT vs YJIT | 1.41x slower (avg) |
 
 ---
 
@@ -78,22 +85,25 @@ Time to convert parsed CSS back to string format
 
 Time to calculate CSS selector specificity values
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
-|-----------|--------|----------------|-------------|
-| Simple Selectors | 1.97M i/s | 419.98K i/s | 1.44M i/s |
-| Compound Selectors | 1.89M i/s | 186.59K i/s | 523.08K i/s |
-| Combinators | 1.43M i/s | 142.61K i/s | 285.41K i/s |
-| Pseudo-classes & Pseudo-elements | 1.41M i/s | 114.7K i/s | 235.07K i/s |
-| :not() Pseudo-class (CSS3) | 1.52M i/s | 110.64K i/s | 247.84K i/s |
-| Complex Real-world Selectors | 1.62M i/s | 56.2K i/s | 126.65K i/s |
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|-----------|--------|----------------|-------------|-------------|
+| Simple Selectors | 1.91M i/s | 411.48K i/s | 1.43M i/s | 750.46K i/s |
+| Compound Selectors | 1.84M i/s | 183.3K i/s | 497.28K i/s | 413.32K i/s |
+| Combinators | 1.38M i/s | 137.21K i/s | 266.34K i/s | 260.6K i/s |
+| Pseudo-classes & Pseudo-elements | 1.37M i/s | 114.36K i/s | 222.19K i/s | 214.48K i/s |
+| :not() Pseudo-class (CSS3) | 1.48M i/s | 110.38K i/s | 243.36K i/s | 190.15K i/s |
+| Complex Real-world Selectors | 1.56M i/s | 55.45K i/s | 120.47K i/s | 120.97K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 13.28x faster (avg) |
-| Native vs Pure (YJIT) | 5.82x faster (avg) |
-| YJIT impact on Pure Ruby | 2.46x faster (avg) |
+| Native vs Pure (no YJIT) | 13.05x faster (avg) |
+| Native vs Pure (YJIT) | 5.91x faster (avg) |
+| Native vs Pure (ZJIT) | 6.56x faster (avg) |
+| YJIT impact on Pure Ruby | 2.41x faster (avg) |
+| ZJIT impact on Pure Ruby | 1.96x faster (avg) |
+| ZJIT vs YJIT | 1.18x slower (avg) |
 
 ---
 
@@ -101,22 +111,25 @@ Time to calculate CSS selector specificity values
 
 Time to flatten multiple CSS rule sets with same selector
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
-|-----------|--------|----------------|-------------|
-| No shorthand properties (large) | 12.75K i/s | 3.69K i/s | 6.41K i/s |
-| Simple properties | 142.64K i/s | 69.09K i/s | 100.71K i/s |
-| Cascade with specificity | 178.29K i/s | 67.87K i/s | 101.77K i/s |
-| Important declarations | 177.88K i/s | 68.12K i/s | 101.75K i/s |
-| Shorthand expansion | 12.75K i/s | 3.69K i/s | 6.41K i/s |
-| Complex flattening | 31.73K i/s | 16.04K i/s | 23.28K i/s |
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|-----------|--------|----------------|-------------|-------------|
+| No shorthand properties (large) | 12.29K i/s | 2.84K i/s | 5.39K i/s | 3.41K i/s |
+| Simple properties | 139.03K i/s | 53.35K i/s | 84.59K i/s | 65.99K i/s |
+| Cascade with specificity | 165.88K i/s | 52.24K i/s | 87.12K i/s | 66.34K i/s |
+| Important declarations | 168.05K i/s | 52.42K i/s | 86.97K i/s | 65.88K i/s |
+| Shorthand expansion | 12.29K i/s | 2.84K i/s | 5.39K i/s | 3.41K i/s |
+| Complex flattening | 31.3K i/s | 11.4K i/s | 17.12K i/s | 14.26K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 2.45x faster (avg) |
-| Native vs Pure (YJIT) | 1.6x faster (avg) |
-| YJIT impact on Pure Ruby | 1.52x faster (avg) |
+| Native vs Pure (no YJIT) | 3.16x faster (avg) |
+| Native vs Pure (YJIT) | 1.88x faster (avg) |
+| Native vs Pure (ZJIT) | 2.53x faster (avg) |
+| YJIT impact on Pure Ruby | 1.67x faster (avg) |
+| ZJIT impact on Pure Ruby | 1.25x faster (avg) |
+| ZJIT vs YJIT | 1.33x slower (avg) |
 
 ---
 
@@ -140,4 +153,5 @@ rake benchmark:generate_docs
 
 - Benchmarks use benchmark-ips with 1-2s warmup and 2-5s measurement periods
 - Measurements show median iterations per second (i/s)
-- YJIT is enabled/disabled per subprocess for accurate comparison
+- YJIT/ZJIT are enabled per subprocess (one JIT per process - Ruby only allows one to be active at a time) for accurate comparison
+- ZJIT is an experimental, method-based JIT introduced in Ruby 4.0. It is not enabled by default and is not yet expected to outperform YJIT; it's included here to track its progress release over release

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -8,51 +8,50 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 
 ## Test Environment
 
-- **Ruby**: ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
+- **Ruby**: ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +ZJIT +PRISM [arm64-darwin25]
 - **CPU**: Apple M1 Pro
 - **Memory**: 32GB
 - **OS**: macOS 26.3.1
-- **Generated**: 2026-07-30T11:56:59-05:00
+- **Generated**: 2026-07-30T21:02:54-05:00
 
 ## CSS Parsing
 
 Time to parse CSS into internal data structures
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|-----------|--------|----------------|-------------|-------------|
-| Small CSS (64 lines, 1.0KB) | 37.58K i/s | 3.33K i/s | 13.84K i/s | 7.56K i/s |
-| Medium CSS with @media (139 lines, 1.6KB) | 34.71K i/s | 2.11K i/s | 8.84K i/s | 4.86K i/s |
-| Selector lists (3500 lines, 62.5KB, 500 lists) | 435.4 i/s | 57.2 i/s | 214.8 i/s | 127.3 i/s |
+| Test Case | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
+| --------- | ------ | ------------- | ----------- | ----------- |
+| Small CSS (64 lines, 1.0KB) | 31.29K i/s | 3.3K i/s | 13.76K i/s | 7.53K i/s |
+| Medium CSS with @media (139 lines, 1.6KB) | 28.46K i/s | 2.06K i/s | 8.88K i/s | 4.78K i/s |
+| Selector lists (3500 lines, 62.5KB, 500 lists) | 369.3 i/s | 57.5 i/s | 216.9 i/s | 125.5 i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 13.96x faster (avg) |
-| Native vs Pure (YJIT) | 3.34x faster (avg) |
-| Native vs Pure (ZJIT) | 5.99x faster (avg) |
+| Native vs Pure (no JIT) | 11.42x faster (avg) |
+| Native vs Pure (YJIT) | 2.74x faster (avg) |
+| Native vs Pure (ZJIT) | 4.92x faster (avg) |
 | YJIT impact on Pure Ruby | 4.15x faster (avg) |
-| ZJIT impact on Pure Ruby | 2.32x faster (avg) |
+| ZJIT impact on Pure Ruby | 2.31x faster (avg) |
 | ZJIT vs YJIT | 1.79x slower (avg) |
 
 ### Parse Error Checking Overhead
 
 Parse error detection can be enabled with `raise_parse_errors: true`. This compares performance impact:
 
-| Configuration | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|---------------|--------|----------------|-------------|-------------|
-| Medium CSS (139 lines) - no error checking | 34.98K i/s | 2.11K i/s | 8.97K i/s | 4.85K i/s |
-| Medium CSS (139 lines) - with error checking | 34.33K i/s | 1.91K i/s | 8.08K i/s | 4.59K i/s |
+| Configuration | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
+| ------------- | ------ | ------------- | ----------- | ----------- |
+| Medium CSS (139 lines) - no error checking | 27.71K i/s | 2.09K i/s | 8.62K i/s | 4.84K i/s |
+| Medium CSS (139 lines) - with error checking | 27.36K i/s | 1.92K i/s | 7.97K i/s | 4.55K i/s |
 
 **Overhead Analysis:**
 
-
 | Implementation | Overhead |
 |----------------|----------|
-| Native | 1.9% slower |
-| Pure (no YJIT) | 10.6% slower |
-| Pure (YJIT) | 11.1% slower |
-| Pure (ZJIT) | 5.7% slower |
+| Native | 1.3% slower |
+| Pure (no JIT) | 9.0% slower |
+| Pure (YJIT) | 8.2% slower |
+| Pure (ZJIT) | 6.3% slower |
 
 ---
 
@@ -60,24 +59,24 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
 Time to convert parsed CSS back to string format
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|-----------|--------|----------------|-------------|-------------|
-| to_s (Bootstrap - 191KB) | 1.05K i/s | 297.2 i/s | 489.0 i/s | 343.3 i/s |
-| to_s (Compact utilities - 2.9KB) | 1.05K i/s | 297.2 i/s | 489.0 i/s | 343.3 i/s |
-| to_formatted_s (Nested CSS - 1.3KB) | 175.44K i/s | 54.96K i/s | 88.31K i/s | 64.77K i/s |
-| to_s with selector_lists (3.4KB) | 15.9K i/s | 6.85K i/s | 10.84K i/s | 8.01K i/s |
-| Media filtering (Bootstrap print only) | 1.17K i/s | 470.2 i/s | 683.1 i/s | 553.6 i/s |
+| Test Case | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
+| --------- | ------ | ------------- | ----------- | ----------- |
+| to_s (Bootstrap - 191KB) | 984.2 i/s | 301.6 i/s | 484.0 i/s | 338.1 i/s |
+| to_s (Compact utilities - 2.9KB) | 50.4K i/s | 11.02K i/s | 18.96K i/s | 10.9K i/s |
+| to_formatted_s (Nested CSS - 1.3KB) | 151.49K i/s | 54.68K i/s | 87.22K i/s | 64.4K i/s |
+| to_s with selector_lists (3.4KB) | 14.99K i/s | 6.72K i/s | 10.69K i/s | 7.87K i/s |
+| Media filtering (Bootstrap print only) | 1.1K i/s | 464.3 i/s | 694.0 i/s | 528.0 i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 3.32x faster (avg) |
-| Native vs Pure (YJIT) | 2.05x faster (avg) |
-| Native vs Pure (ZJIT) | 2.99x faster (avg) |
+| Native vs Pure (no JIT) | 3.04x faster (avg) |
+| Native vs Pure (YJIT) | 1.88x faster (avg) |
+| Native vs Pure (ZJIT) | 2.77x faster (avg) |
 | YJIT impact on Pure Ruby | 1.6x faster (avg) |
-| ZJIT impact on Pure Ruby | 1.13x faster (avg) |
-| ZJIT vs YJIT | 1.41x slower (avg) |
+| ZJIT impact on Pure Ruby | 1.12x faster (avg) |
+| ZJIT vs YJIT | 1.43x slower (avg) |
 
 ---
 
@@ -85,25 +84,25 @@ Time to convert parsed CSS back to string format
 
 Time to calculate CSS selector specificity values
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|-----------|--------|----------------|-------------|-------------|
-| Simple Selectors | 1.91M i/s | 411.48K i/s | 1.43M i/s | 750.46K i/s |
-| Compound Selectors | 1.84M i/s | 183.3K i/s | 497.28K i/s | 413.32K i/s |
-| Combinators | 1.38M i/s | 137.21K i/s | 266.34K i/s | 260.6K i/s |
-| Pseudo-classes & Pseudo-elements | 1.37M i/s | 114.36K i/s | 222.19K i/s | 214.48K i/s |
-| :not() Pseudo-class (CSS3) | 1.48M i/s | 110.38K i/s | 243.36K i/s | 190.15K i/s |
-| Complex Real-world Selectors | 1.56M i/s | 55.45K i/s | 120.47K i/s | 120.97K i/s |
+| Test Case | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
+| --------- | ------ | ------------- | ----------- | ----------- |
+| Simple Selectors | 1.02M i/s | 413.96K i/s | 1.43M i/s | 749.57K i/s |
+| Compound Selectors | 997.92K i/s | 183.13K i/s | 498.8K i/s | 404.43K i/s |
+| Combinators | 757.46K i/s | 136.54K i/s | 267.01K i/s | 260.74K i/s |
+| Pseudo-classes & Pseudo-elements | 757.92K i/s | 113.58K i/s | 224.99K i/s | 209.63K i/s |
+| :not() Pseudo-class (CSS3) | 883.15K i/s | 110.53K i/s | 237.8K i/s | 189.57K i/s |
+| Complex Real-world Selectors | 913.36K i/s | 55.32K i/s | 120.83K i/s | 116.13K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 13.05x faster (avg) |
-| Native vs Pure (YJIT) | 5.91x faster (avg) |
-| Native vs Pure (ZJIT) | 6.56x faster (avg) |
+| Native vs Pure (no JIT) | 7.44x faster (avg) |
+| Native vs Pure (YJIT) | 3.37x faster (avg) |
+| Native vs Pure (ZJIT) | 3.81x faster (avg) |
 | YJIT impact on Pure Ruby | 2.41x faster (avg) |
-| ZJIT impact on Pure Ruby | 1.96x faster (avg) |
-| ZJIT vs YJIT | 1.18x slower (avg) |
+| ZJIT impact on Pure Ruby | 1.93x faster (avg) |
+| ZJIT vs YJIT | 1.2x slower (avg) |
 
 ---
 
@@ -111,24 +110,24 @@ Time to calculate CSS selector specificity values
 
 Time to flatten multiple CSS rule sets with same selector
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|-----------|--------|----------------|-------------|-------------|
-| No shorthand properties (large) | 12.29K i/s | 2.84K i/s | 5.39K i/s | 3.41K i/s |
-| Simple properties | 139.03K i/s | 53.35K i/s | 84.59K i/s | 65.99K i/s |
-| Cascade with specificity | 165.88K i/s | 52.24K i/s | 87.12K i/s | 66.34K i/s |
-| Important declarations | 168.05K i/s | 52.42K i/s | 86.97K i/s | 65.88K i/s |
-| Shorthand expansion | 12.29K i/s | 2.84K i/s | 5.39K i/s | 3.41K i/s |
-| Complex flattening | 31.3K i/s | 11.4K i/s | 17.12K i/s | 14.26K i/s |
+| Test Case | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
+| --------- | ------ | ------------- | ----------- | ----------- |
+| No shorthand properties (large) | 13.28K i/s | 2.85K i/s | 5.37K i/s | 3.44K i/s |
+| Simple properties | 138.9K i/s | 54.39K i/s | 84.42K i/s | 65.18K i/s |
+| Cascade with specificity | 168.14K i/s | 52.88K i/s | 86.97K i/s | 65.61K i/s |
+| Important declarations | 167.4K i/s | 53.61K i/s | 87.29K i/s | 65.6K i/s |
+| Shorthand expansion | 132.57K i/s | 46.27K i/s | 78.43K i/s | 58.86K i/s |
+| Complex flattening | 32.18K i/s | 11.32K i/s | 17.41K i/s | 14.11K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no YJIT) | 3.16x faster (avg) |
-| Native vs Pure (YJIT) | 1.88x faster (avg) |
-| Native vs Pure (ZJIT) | 2.53x faster (avg) |
-| YJIT impact on Pure Ruby | 1.67x faster (avg) |
-| ZJIT impact on Pure Ruby | 1.25x faster (avg) |
+| Native vs Pure (no JIT) | 3.2x faster (avg) |
+| Native vs Pure (YJIT) | 1.92x faster (avg) |
+| Native vs Pure (ZJIT) | 2.61x faster (avg) |
+| YJIT impact on Pure Ruby | 1.66x faster (avg) |
+| ZJIT impact on Pure Ruby | 1.23x faster (avg) |
 | ZJIT vs YJIT | 1.33x slower (avg) |
 
 ---
@@ -153,5 +152,6 @@ rake benchmark:generate_docs
 
 - Benchmarks use benchmark-ips with 1-2s warmup and 2-5s measurement periods
 - Measurements show median iterations per second (i/s)
-- YJIT/ZJIT are enabled per subprocess (one JIT per process - Ruby only allows one to be active at a time) for accurate comparison
+- Each backend/JIT combination is measured in its own subprocess - Ruby allows only one JIT active per process, and each subprocess verifies the JIT it was launched with is the one actually running before measuring anything
+- The C extension is measured without a JIT: its speed doesn't depend on a JIT compiling Cataract's own code
 - ZJIT is an experimental, method-based JIT introduced in Ruby 4.0. It is not enabled by default and is not yet expected to outperform YJIT; it's included here to track its progress release over release

--- a/benchmarks/backend.rb
+++ b/benchmarks/backend.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative 'ruby_mode'
+
+# A Cataract implementation under test: pure Ruby or the C extension.
+#
+# Each backend declares which RubyModes it is benchmarked under. The C
+# extension declares only one - a JIT doesn't compile its code, so further
+# modes would resample the same number.
+class Backend
+  # Read by Cataract at require time to pick a backend.
+  SELECTION_ENV_VAR = 'CATARACT_PURE'
+
+  # Set by a parent process to declare which backend a worker should load.
+  ENV_VAR = 'CATARACT_BENCH_BACKEND'
+
+  Mismatch = Class.new(StandardError)
+
+  attr_reader :id, :label, :column_label, :modes, :selection_env
+
+  def initialize(id:, label:, column_label:, modes:, selection_env:)
+    @id = id
+    @label = label
+    @column_label = column_label
+    @modes = modes.freeze
+    @selection_env = selection_env.freeze
+    freeze
+  end
+
+  def to_s
+    label
+  end
+
+  NATIVE = new(
+    id: :native,
+    label: 'cataract',
+    column_label: 'Native',
+    modes: [RubyMode::NO_JIT].freeze,
+    selection_env: { SELECTION_ENV_VAR => nil }.freeze
+  )
+
+  PURE = new(
+    id: :pure,
+    label: 'cataract pure',
+    column_label: 'Pure',
+    modes: [RubyMode::NO_JIT, RubyMode::YJIT, RubyMode::ZJIT].freeze,
+    selection_env: { SELECTION_ENV_VAR => '1' }.freeze
+  )
+
+  # Drives both the order variants run in and the column order in
+  # BENCHMARKS.md.
+  ALL = [NATIVE, PURE].freeze
+
+  def self.fetch(id)
+    ALL.find { |backend| backend.id == id.to_sym } ||
+      raise(ArgumentError, "unknown backend #{id.inspect} (known: #{ALL.map(&:id).join(', ')})")
+  end
+
+  # The backend behind a loaded Cataract.
+  #
+  # @param loaded [Symbol] the value of Cataract::IMPLEMENTATION
+  def self.active(loaded = Cataract::IMPLEMENTATION)
+    loaded == :ruby ? PURE : NATIVE
+  end
+
+  # The backend named by the environment, or nil if it names none.
+  def self.expected(env)
+    id = env[ENV_VAR]
+    id && fetch(id)
+  end
+
+  # Returns `actual`, or raises if it isn't what was expected.
+  def self.verify!(actual:, expected:)
+    return actual if expected.nil? || expected.equal?(actual)
+
+    raise Mismatch,
+          "expected to have loaded the #{expected.label} backend (#{ENV_VAR}=#{expected.id}) but " \
+          "Cataract::IMPLEMENTATION reports #{actual.label} is loaded"
+  end
+end

--- a/benchmarks/benchmark_flattening.rb
+++ b/benchmarks/benchmark_flattening.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'benchmark_harness'
-require 'open3'
+require_relative 'flattening_tests'
 
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'cataract'
 
 # CSS Flattening Benchmark
-# Compares Cataract pure Ruby vs Cataract C extension
+#
+# Orchestration only - one subprocess per Implementation. The measuring
+# happens in benchmark_flattening_workers.rb.
 class FlatteningBenchmark < BenchmarkHarness
   def self.benchmark_name
     'flattening'
@@ -19,165 +21,18 @@ class FlatteningBenchmark < BenchmarkHarness
   end
 
   def self.metadata
-    require_relative 'flattening_tests'
     FlatteningTests.metadata
   end
 
-  def self.speedup_config
-    require_relative 'flattening_tests'
-    FlatteningTests.speedup_config
-  end
-
   def sanity_checks
-    # Verify cataract works
     css = ".test { color: black; }\n.test { margin: 10px; }"
-    cataract_rules = Cataract.parse_css(css)
-    cataract_flattened = Cataract.flatten(cataract_rules)
+    cataract_flattened = Cataract.flatten(Cataract.parse_css(css))
     raise 'Cataract sanity check failed' if cataract_flattened.rules.empty?
   end
 
   def call
-    require_relative 'flattening_tests'
-
-    worker_script = File.expand_path('benchmark_flattening_workers.rb', __dir__)
-
-    # Clean up any leftover worker files from previous runs
-    Dir.glob(File.join(RESULTS_DIR, 'flattening_*.json')).each { |f| FileUtils.rm_f(f) }
-
-    puts 'Running flattening benchmarks via subprocesses...'
-    puts 'Testing implementations with JIT variations (none/YJIT/ZJIT) where applicable'
-    puts
-
-    # Define implementations to test - run via subprocess (see BenchmarkHarness
-    # for why: in-process comparison measurably distorts pure Ruby's numbers
-    # under YJIT).
-    implementations = [
-      { name: 'Cataract pure Ruby', base_impl: :pure, env: { 'CATARACT_PURE' => '1' } },
-      { name: 'Cataract C extension', base_impl: :native, env: { 'CATARACT_PURE' => nil } }
-    ]
-
-    implementations.each do |config|
-      if FlatteningTests.yjit_applicable?(config[:base_impl])
-        # Run all JIT variants. CATARACT_BENCH_JIT tells the worker which
-        # mode we intended (see WorkerHelpers#verify_jit_mode!) so it can
-        # raise loudly if the actual JIT active doesn't match - e.g. a Ruby
-        # build without YJIT/ZJIT support silently falling back to the
-        # interpreter instead of honoring --yjit/--zjit.
-        puts "→ Running #{config[:name]} without YJIT..."
-        puts
-        _, status = run_subprocess(['ruby', '--disable-yjit', worker_script],
-                                   env: config[:env].merge('CATARACT_BENCH_JIT' => 'none'))
-        raise "#{config[:name]} (no YJIT) benchmark failed" unless status.success?
-
-        puts
-        puts
-
-        puts "→ Running #{config[:name]} with YJIT..."
-        puts
-        _, status = run_subprocess(['ruby', '--yjit', worker_script],
-                                   env: config[:env].merge('CATARACT_BENCH_JIT' => 'yjit'))
-        raise "#{config[:name]} (YJIT) benchmark failed" unless status.success?
-
-        puts
-        puts
-
-        puts "→ Running #{config[:name]} with ZJIT..."
-        puts
-        _, status = run_subprocess(['ruby', '--zjit', worker_script],
-                                   env: config[:env].merge('CATARACT_BENCH_JIT' => 'zjit'))
-        raise "#{config[:name]} (ZJIT) benchmark failed" unless status.success?
-
-      else
-        # Run without YJIT flags (YJIT not applicable)
-        puts "→ Running #{config[:name]}..."
-        puts
-        _, status = run_subprocess(['ruby', worker_script], env: config[:env])
-        raise "#{config[:name]} benchmark failed" unless status.success?
-
-      end
-      puts
-      puts
-    end
-
-    # Combine results
-    combine_worker_results
-  end
-
-  private
-
-  def run_subprocess(command, env: {})
-    stdout_lines = []
-
-    Open3.popen3(env, *command) do |stdin, stdout, stderr, wait_thr|
-      stdin.close
-
-      # Stream output in real-time
-      threads = []
-
-      # Thread for stdout
-      threads << Thread.new do
-        stdout.each_line do |line|
-          puts line
-          stdout_lines << line
-        end
-      end
-
-      # Thread for stderr
-      threads << Thread.new do
-        stderr.each_line do |line|
-          warn "⚠️  #{line}"
-        end
-      end
-
-      # Wait for all output to be read
-      threads.each(&:join)
-
-      # Get exit status
-      status = wait_thr.value
-
-      return [stdout_lines.join, status]
-    end
-  end
-
-  def combine_worker_results
-    # Read all worker result files
-    all_results = read_worker_results('flattening_*.json')
-
-    # Combine into single result
-    combined = {
-      'name' => self.class.benchmark_name,
-      'description' => self.class.description,
-      'metadata' => self.class.metadata,
-      'results' => all_results
-    }
-
-    # Calculate speedups using configured strategy
-    require_relative 'speedup_calculator'
-    config = self.class.speedup_config
-    if config
-      calculator = SpeedupCalculator.new(
-        results: combined['results'],
-        test_cases: combined['metadata']['test_cases'],
-        baseline_matcher: config[:baseline_matcher],
-        comparison_matcher: config[:comparison_matcher],
-        test_case_key: config[:test_case_key]
-      )
-
-      speedup_stats = calculator.calculate
-      combined['metadata']['speedups'] = speedup_stats if speedup_stats
-    end
-
-    # Write combined results
-    combined_path = File.join(RESULTS_DIR, "#{self.class.benchmark_name}.json")
-    File.write(combined_path, JSON.pretty_generate(combined))
-
-    # Clean up worker files
-    cleanup_worker_results('flattening_*.json')
-
-    puts '=' * 80
-    puts '✓ All flattening benchmarks complete'
-    puts "Results saved to: #{combined_path}"
-    puts '=' * 80
+    announce_variants
+    run_all_variants(File.expand_path('benchmark_flattening_workers.rb', __dir__))
   end
 end
 

--- a/benchmarks/benchmark_flattening.rb
+++ b/benchmarks/benchmark_flattening.rb
@@ -45,7 +45,7 @@ class FlatteningBenchmark < BenchmarkHarness
     Dir.glob(File.join(RESULTS_DIR, 'flattening_*.json')).each { |f| FileUtils.rm_f(f) }
 
     puts 'Running flattening benchmarks via subprocesses...'
-    puts 'Testing implementations with YJIT variations where applicable'
+    puts 'Testing implementations with JIT variations (none/YJIT/ZJIT) where applicable'
     puts
 
     # Define implementations to test - run via subprocess (see BenchmarkHarness
@@ -58,10 +58,15 @@ class FlatteningBenchmark < BenchmarkHarness
 
     implementations.each do |config|
       if FlatteningTests.yjit_applicable?(config[:base_impl])
-        # Run both YJIT variants
+        # Run all JIT variants. CATARACT_BENCH_JIT tells the worker which
+        # mode we intended (see WorkerHelpers#verify_jit_mode!) so it can
+        # raise loudly if the actual JIT active doesn't match - e.g. a Ruby
+        # build without YJIT/ZJIT support silently falling back to the
+        # interpreter instead of honoring --yjit/--zjit.
         puts "→ Running #{config[:name]} without YJIT..."
         puts
-        _, status = run_subprocess(['ruby', '--disable-yjit', worker_script], env: config[:env])
+        _, status = run_subprocess(['ruby', '--disable-yjit', worker_script],
+                                   env: config[:env].merge('CATARACT_BENCH_JIT' => 'none'))
         raise "#{config[:name]} (no YJIT) benchmark failed" unless status.success?
 
         puts
@@ -69,8 +74,18 @@ class FlatteningBenchmark < BenchmarkHarness
 
         puts "→ Running #{config[:name]} with YJIT..."
         puts
-        _, status = run_subprocess(['ruby', '--yjit', worker_script], env: config[:env])
+        _, status = run_subprocess(['ruby', '--yjit', worker_script],
+                                   env: config[:env].merge('CATARACT_BENCH_JIT' => 'yjit'))
         raise "#{config[:name]} (YJIT) benchmark failed" unless status.success?
+
+        puts
+        puts
+
+        puts "→ Running #{config[:name]} with ZJIT..."
+        puts
+        _, status = run_subprocess(['ruby', '--zjit', worker_script],
+                                   env: config[:env].merge('CATARACT_BENCH_JIT' => 'zjit'))
+        raise "#{config[:name]} (ZJIT) benchmark failed" unless status.success?
 
       else
         # Run without YJIT flags (YJIT not applicable)

--- a/benchmarks/benchmark_flattening_workers.rb
+++ b/benchmarks/benchmark_flattening_workers.rb
@@ -30,7 +30,7 @@ class MergingCataractPureBenchmark < BenchmarkHarness
 
   def initialize
     super
-    self.impl_type = determine_impl_type_with_yjit(:pure, FlatteningTests)
+    self.impl_type = determine_impl_type(:pure, FlatteningTests)
   end
 end
 
@@ -57,7 +57,7 @@ class MergingCataractNativeBenchmark < BenchmarkHarness
 
   def initialize
     super
-    self.impl_type = determine_impl_type_with_yjit(:native, FlatteningTests)
+    self.impl_type = determine_impl_type(:native, FlatteningTests)
   end
 end
 

--- a/benchmarks/benchmark_flattening_workers.rb
+++ b/benchmarks/benchmark_flattening_workers.rb
@@ -7,67 +7,29 @@ require_relative 'worker_helpers'
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-# Worker benchmark: Cataract pure Ruby
-class MergingCataractPureBenchmark < BenchmarkHarness
+# Measures CSS flattening for whichever configuration this process was
+# launched as. One class covers every variant: WorkerHelpers reads the
+# backend and JIT off the running VM and verifies them, so there is nothing
+# per-variant to subclass.
+class FlatteningWorkerBenchmark < BenchmarkHarness
   include FlatteningTests
   include WorkerHelpers
 
   def self.benchmark_name
-    'flattening_cataract_pure'
+    'flattening'
   end
 
   def self.description
-    'CSS flattening with Cataract pure Ruby'
+    'CSS flattening (cascade)'
   end
 
   def self.metadata
     FlatteningTests.metadata
   end
-
-  def self.speedup_config
-    FlatteningTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type(:pure, FlatteningTests)
-  end
 end
 
-# Worker benchmark: Cataract C extension
-class MergingCataractNativeBenchmark < BenchmarkHarness
-  include FlatteningTests
-  include WorkerHelpers
-
-  def self.benchmark_name
-    'flattening_cataract_native'
-  end
-
-  def self.description
-    'CSS flattening with Cataract C extension'
-  end
-
-  def self.metadata
-    FlatteningTests.metadata
-  end
-
-  def self.speedup_config
-    FlatteningTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type(:native, FlatteningTests)
-  end
-end
-
-# CLI entry point - run the appropriate worker
+# CLI entry point
 if __FILE__ == $PROGRAM_NAME
   require 'cataract'
-
-  if Cataract::IMPLEMENTATION == :ruby
-    MergingCataractPureBenchmark.run(skip_finalize: true)
-  else
-    MergingCataractNativeBenchmark.run(skip_finalize: true)
-  end
+  FlatteningWorkerBenchmark.run(skip_finalize: true)
 end

--- a/benchmarks/benchmark_formatting.rb
+++ b/benchmarks/benchmark_formatting.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Shared presentation of benchmark numbers for BENCHMARKS.md.
+module BenchmarkFormatting
+  # Cell content when an implementation has no measurement for a test case.
+  MISSING = 'N/A'
+
+  def format_ips(result, short: false)
+    return MISSING unless result
+
+    ips = result['central_tendency']
+    formatted = if ips >= 1_000_000
+                  "#{(ips / 1_000_000.0).round(2)}M"
+                elsif ips >= 1_000
+                  "#{(ips / 1_000.0).round(2)}K"
+                else
+                  ips.round(1).to_s
+                end
+
+    short ? "#{formatted} i/s" : "#{formatted} i/s (#{format_time_per_op(result)})"
+  end
+
+  def format_time_per_op(result)
+    time_us = 1_000_000.0 / result['central_tendency']
+
+    if time_us >= 1_000
+      "#{(time_us / 1_000).round(2)} ms"
+    else
+      "#{time_us.round(2)} μs"
+    end
+  end
+
+  # Renders a ratio as "Nx faster" or, below 1, its reciprocal as "Nx
+  # slower".
+  def format_speedup(speedup)
+    return MISSING if speedup.nil?
+    return "#{speedup.round(2)}x faster" if speedup >= 1
+
+    "#{(1.0 / speedup).round(2)}x slower"
+  end
+
+  # Cost of enabling a feature, as a percentage of the rate without it.
+  def format_overhead(without, with)
+    return MISSING unless without && with
+
+    slowdown = ((without['central_tendency'] / with['central_tendency']) - 1) * 100
+
+    if slowdown.abs < 1.0
+      '~0% (within noise)'
+    elsif slowdown.negative?
+      format('%.1f%% faster (unexpected)', slowdown.abs)
+    else
+      format('%.1f%% slower', slowdown)
+    end
+  end
+end

--- a/benchmarks/benchmark_harness.rb
+++ b/benchmarks/benchmark_harness.rb
@@ -257,7 +257,7 @@ class BenchmarkHarness
 
   def announce_variants
     puts "Running #{self.class.benchmark_name} benchmarks via subprocesses..."
-    puts "Variants: #{Implementation.all.map(&:label).join(', ')}"
+    puts "Variants: #{Implementation.available.map(&:label).join(', ')}"
     puts
   end
 
@@ -266,7 +266,7 @@ class BenchmarkHarness
   def run_all_variants(worker_script)
     cleanup_worker_results(worker_glob)
 
-    Implementation.all.each do |implementation|
+    Implementation.available.each do |implementation|
       puts "→ Running #{implementation}..."
       puts
       # Workers write into the same directory as their parent, so a redirected

--- a/benchmarks/benchmark_harness.rb
+++ b/benchmarks/benchmark_harness.rb
@@ -3,8 +3,11 @@
 require 'benchmark/ips'
 require 'json'
 require 'fileutils'
+require 'open3'
 require_relative 'system_metadata'
 require_relative 'speedup_calculator'
+require_relative 'implementation'
+require_relative 'results_directory'
 
 # Base class for all benchmarks. Provides structure and automatic JSON output.
 #
@@ -57,7 +60,13 @@ require_relative 'speedup_calculator'
 # not just YJIT-disabled ones, per-implementation subprocess isolation stays
 # even though it could technically be done in-process.
 class BenchmarkHarness
-  RESULTS_DIR = File.expand_path('.results', __dir__)
+  # Where this run's result JSON lives. Passed in rather than looked up, so a
+  # test can redirect it without touching global state.
+  attr_reader :results
+
+  def initialize(results:)
+    @results = results
+  end
 
   class << self
     # Abstract methods - must be implemented by subclasses
@@ -81,31 +90,22 @@ class BenchmarkHarness
       raise NotImplementedError, "#{self} must implement .call"
     end
 
-    # Optional: Define how to calculate speedups for this benchmark
-    # Override this to customize speedup calculation
+    # The pair compared by the headline "speedups" figure in this benchmark's
+    # metadata. Both sides run without a JIT, isolating the C extension's
+    # advantage from anything a JIT contributed.
     #
-    # IMPORTANT: Result names must follow convention "tool_name: test_case_id"
-    #
-    # @return [Hash] Configuration for SpeedupCalculator
-    #   {
-    #     baseline_matcher: Proc,      # Returns true for baseline results
-    #     comparison_matcher: Proc,    # Returns true for comparison results
-    #     test_case_key: Symbol        # Key in test_cases metadata matching test_case_id
-    #   }
+    # @return [Hash] { baseline: Implementation, comparison: Implementation }
     def speedup_config
-      # Default: compare cataract pure without YJIT (baseline) vs cataract native (comparison)
-      # Match to test_cases by 'fixture' key
       {
-        baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-        comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-        test_case_key: :fixture
+        baseline: Implementation.find(:pure, :none),
+        comparison: Implementation.find(:native, :none)
       }
     end
 
     # Main entry point - handles setup, execution, and cleanup
-    def run(skip_finalize: false)
-      instance = new
-      setup
+    def run(skip_finalize: false, results: ResultsDirectory.from_env(ENV))
+      instance = new(results: results)
+      setup(results)
       instance.sanity_checks if instance.respond_to?(:sanity_checks, true)
 
       # Warm up the VM before benchmarking for stable, reproducible results
@@ -122,10 +122,26 @@ class BenchmarkHarness
       exit 1
     end
 
+    # Fills in metadata['speedups'] (and each test case's own 'speedup') from
+    # the pair named by speedup_config.
+    def annotate_speedups(combined_data)
+      config = speedup_config
+      return unless config
+
+      stats = SpeedupCalculator.new(
+        results: combined_data['results'],
+        test_cases: combined_data['metadata']['test_cases'],
+        baseline: config[:baseline],
+        comparison: config[:comparison]
+      ).calculate
+
+      combined_data['metadata']['speedups'] = stats if stats
+    end
+
     private
 
-    def setup
-      FileUtils.mkdir_p(RESULTS_DIR)
+    def setup(results)
+      results.create
 
       # Always refresh - each of the 4 benchmark scripts runs in its own
       # subprocess, so metadata.json existing doesn't mean it reflects THIS
@@ -137,7 +153,7 @@ class BenchmarkHarness
       # actual numbers below it came from whatever's currently installed.
       # The four sysctl/sw_vers shell calls this costs per full `rake
       # benchmark` run are cheap; a stale, silently-wrong header is not.
-      SystemMetadata.collect
+      SystemMetadata.collect(results)
 
       # Print header
       puts "\n\n"
@@ -164,38 +180,22 @@ class BenchmarkHarness
 
       # Read all the individual JSON files
       json_files.each do |filename|
-        path = File.join(RESULTS_DIR, filename)
-        next unless File.exist?(path)
+        next unless instance.results.exist?(filename)
 
-        data = JSON.parse(File.read(path))
+        data = instance.results.read(filename)
         combined_data['results'].concat(data) if data.is_a?(Array)
       end
 
-      # Calculate speedups using configured strategy
-      config = speedup_config
-      if config
-        calculator = SpeedupCalculator.new(
-          results: combined_data['results'],
-          test_cases: combined_data['metadata']['test_cases'],
-          baseline_matcher: config[:baseline_matcher],
-          comparison_matcher: config[:comparison_matcher],
-          test_case_key: config[:test_case_key]
-        )
-
-        speedup_stats = calculator.calculate
-        combined_data['metadata']['speedups'] = speedup_stats if speedup_stats
-      end
+      annotate_speedups(combined_data)
 
       # Write combined file
-      combined_path = File.join(RESULTS_DIR, "#{benchmark_name}.json")
-      File.write(combined_path, JSON.pretty_generate(combined_data))
+      combined_file = "#{benchmark_name}.json"
+      instance.results.write(combined_file, combined_data)
 
       # Clean up individual files
-      json_files.each do |filename|
-        File.delete(File.join(RESULTS_DIR, filename))
-      end
+      json_files.each { |filename| File.delete(instance.results.join(filename)) }
 
-      puts "\n✓ Results saved to #{combined_path}"
+      puts "\n✓ Results saved to #{instance.results.join(combined_file)}"
     end
   end
 
@@ -211,7 +211,7 @@ class BenchmarkHarness
 
   def benchmark(test_case_name)
     json_filename = "#{benchmark_name}_#{test_case_name}.json"
-    json_path = File.join(RESULTS_DIR, json_filename)
+    json_path = results.join(json_filename)
 
     Benchmark.ips do |x|
       # Automatically enable JSON output
@@ -221,10 +221,13 @@ class BenchmarkHarness
       yield x
     end
 
-    # Add implementation metadata to each result in the JSON file
-    if File.exist?(json_path) && respond_to?(:impl_type) && impl_type
+    # Tag each measurement with the implementation that produced it and the
+    # JIT stats at that point. Stats are cumulative for the process, so the
+    # last test case's snapshot is the run's total.
+    if File.exist?(json_path) && respond_to?(:implementation) && implementation
+      fields = implementation.result_fields.merge('jit_stats' => implementation.mode.stats)
       results = JSON.parse(File.read(json_path))
-      results.each { |result| result['implementation'] = impl_type.to_s }
+      results.each { |result| result.merge!(fields) }
       File.write(json_path, JSON.pretty_generate(results))
     end
 
@@ -236,7 +239,7 @@ class BenchmarkHarness
   # Helper to read and combine worker result files
   # Worker files are raw arrays from benchmark-ips, not hashes with 'results' key
   def read_worker_results(pattern)
-    worker_paths = Dir.glob(File.join(RESULTS_DIR, pattern))
+    worker_paths = results.glob(pattern)
     raise 'No worker results found' if worker_paths.empty?
 
     all_results = []
@@ -249,6 +252,80 @@ class BenchmarkHarness
 
   # Helper to clean up worker result files
   def cleanup_worker_results(pattern)
-    Dir.glob(File.join(RESULTS_DIR, pattern)).each { |p| File.delete(p) }
+    results.delete(pattern)
+  end
+
+  def announce_variants
+    puts "Running #{self.class.benchmark_name} benchmarks via subprocesses..."
+    puts "Variants: #{Implementation.all.map(&:label).join(', ')}"
+    puts
+  end
+
+  # Runs a worker script once per Implementation, each in its own process,
+  # then merges their output into this benchmark's combined results file.
+  def run_all_variants(worker_script)
+    cleanup_worker_results(worker_glob)
+
+    Implementation.all.each do |implementation|
+      puts "→ Running #{implementation}..."
+      puts
+      # Workers write into the same directory as their parent, so a redirected
+      # results location survives the process boundary.
+      env = implementation.env.merge(results.env)
+      _, status = run_subprocess(implementation.ruby_command(worker_script), env: env)
+      raise "#{implementation} benchmark failed" unless status.success?
+
+      puts
+      puts
+    end
+
+    combine_worker_results
+  end
+
+  private
+
+  def worker_glob
+    "#{self.class.benchmark_name}_*.json"
+  end
+
+  def run_subprocess(command, env: {})
+    stdout_lines = []
+
+    Open3.popen3(env, *command) do |stdin, stdout, stderr, wait_thr|
+      stdin.close
+
+      # Stream both streams as they arrive so a long benchmark isn't silent
+      readers = [
+        Thread.new do
+          stdout.each_line do |line|
+            puts line
+            stdout_lines << line
+          end
+        end,
+        Thread.new { stderr.each_line { |line| warn "⚠️  #{line}" } }
+      ]
+      readers.each(&:join)
+
+      return [stdout_lines.join, wait_thr.value]
+    end
+  end
+
+  def combine_worker_results
+    combined = {
+      'name' => self.class.benchmark_name,
+      'description' => self.class.description,
+      'metadata' => self.class.metadata,
+      'results' => read_worker_results(worker_glob)
+    }
+    self.class.annotate_speedups(combined)
+
+    combined_file = "#{self.class.benchmark_name}.json"
+    results.write(combined_file, combined)
+    cleanup_worker_results(worker_glob)
+
+    puts '=' * 80
+    puts "✓ All #{self.class.benchmark_name} benchmarks complete"
+    puts "Results saved to: #{results.join(combined_file)}"
+    puts '=' * 80
   end
 end

--- a/benchmarks/benchmark_parsing.rb
+++ b/benchmarks/benchmark_parsing.rb
@@ -52,7 +52,7 @@ class ParsingBenchmark < BenchmarkHarness
     Dir.glob(File.join(RESULTS_DIR, 'parsing_*.json')).each { |f| FileUtils.rm_f(f) }
 
     puts 'Running parsing benchmarks via subprocesses...'
-    puts 'Testing implementations with YJIT variations where applicable'
+    puts 'Testing implementations with JIT variations (none/YJIT/ZJIT) where applicable'
     puts
 
     # Define implementations to test - run via subprocess (see BenchmarkHarness
@@ -65,18 +65,32 @@ class ParsingBenchmark < BenchmarkHarness
 
     implementations.each do |config|
       if ParsingTests.yjit_applicable?(config[:base_impl])
-        # Run both YJIT variants
+        # Run all JIT variants. CATARACT_BENCH_JIT tells the worker which
+        # mode we intended (see WorkerHelpers#verify_jit_mode!) so it can
+        # raise loudly if the actual JIT active doesn't match - e.g. a Ruby
+        # build without YJIT/ZJIT support silently falling back to the
+        # interpreter instead of honoring --yjit/--zjit.
         puts "→ Running #{config[:name]} without YJIT..."
         puts
-        stdout, status = run_subprocess(['ruby', '--disable-yjit', worker_script], env: config[:env])
+        stdout, status = run_subprocess(['ruby', '--disable-yjit', worker_script],
+                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'none'))
         raise "#{config[:name]} (no YJIT) benchmark failed" unless status.success?
         puts
         puts
 
         puts "→ Running #{config[:name]} with YJIT..."
         puts
-        stdout, status = run_subprocess(['ruby', '--yjit', worker_script], env: config[:env])
+        stdout, status = run_subprocess(['ruby', '--yjit', worker_script],
+                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'yjit'))
         raise "#{config[:name]} (YJIT) benchmark failed" unless status.success?
+        puts
+        puts
+
+        puts "→ Running #{config[:name]} with ZJIT..."
+        puts
+        stdout, status = run_subprocess(['ruby', '--zjit', worker_script],
+                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'zjit'))
+        raise "#{config[:name]} (ZJIT) benchmark failed" unless status.success?
         puts
         puts
       else

--- a/benchmarks/benchmark_parsing.rb
+++ b/benchmarks/benchmark_parsing.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'benchmark_harness'
-require 'open3'
+require_relative 'parsing_tests'
 
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'cataract'
 
 # CSS Parsing Performance Benchmark
-# Compares Cataract pure Ruby vs Cataract C extension
+#
+# Orchestration only - one subprocess per Implementation. The measuring
+# happens in benchmark_parsing_workers.rb.
 class ParsingBenchmark < BenchmarkHarness
   def self.benchmark_name
     'parsing'
@@ -19,13 +21,7 @@ class ParsingBenchmark < BenchmarkHarness
   end
 
   def self.metadata
-    require_relative 'parsing_tests'
     ParsingTests.metadata
-  end
-
-  def self.speedup_config
-    require_relative 'parsing_tests'
-    ParsingTests.speedup_config
   end
 
   def sanity_checks
@@ -44,145 +40,8 @@ class ParsingBenchmark < BenchmarkHarness
   end
 
   def call
-    require_relative 'parsing_tests'
-
-    worker_script = File.expand_path('benchmark_parsing_workers.rb', __dir__)
-
-    # Clean up any leftover worker files from previous runs
-    Dir.glob(File.join(RESULTS_DIR, 'parsing_*.json')).each { |f| FileUtils.rm_f(f) }
-
-    puts 'Running parsing benchmarks via subprocesses...'
-    puts 'Testing implementations with JIT variations (none/YJIT/ZJIT) where applicable'
-    puts
-
-    # Define implementations to test - run via subprocess (see BenchmarkHarness
-    # for why: in-process comparison measurably distorts pure Ruby's numbers
-    # under YJIT).
-    implementations = [
-      { name: 'Cataract pure Ruby', base_impl: :pure, env: { 'CATARACT_PURE' => '1' } },
-      { name: 'Cataract C extension', base_impl: :native, env: { 'CATARACT_PURE' => nil } }
-    ]
-
-    implementations.each do |config|
-      if ParsingTests.yjit_applicable?(config[:base_impl])
-        # Run all JIT variants. CATARACT_BENCH_JIT tells the worker which
-        # mode we intended (see WorkerHelpers#verify_jit_mode!) so it can
-        # raise loudly if the actual JIT active doesn't match - e.g. a Ruby
-        # build without YJIT/ZJIT support silently falling back to the
-        # interpreter instead of honoring --yjit/--zjit.
-        puts "→ Running #{config[:name]} without YJIT..."
-        puts
-        stdout, status = run_subprocess(['ruby', '--disable-yjit', worker_script],
-                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'none'))
-        raise "#{config[:name]} (no YJIT) benchmark failed" unless status.success?
-        puts
-        puts
-
-        puts "→ Running #{config[:name]} with YJIT..."
-        puts
-        stdout, status = run_subprocess(['ruby', '--yjit', worker_script],
-                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'yjit'))
-        raise "#{config[:name]} (YJIT) benchmark failed" unless status.success?
-        puts
-        puts
-
-        puts "→ Running #{config[:name]} with ZJIT..."
-        puts
-        stdout, status = run_subprocess(['ruby', '--zjit', worker_script],
-                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'zjit'))
-        raise "#{config[:name]} (ZJIT) benchmark failed" unless status.success?
-        puts
-        puts
-      else
-        # Run without YJIT flags (YJIT not applicable)
-        puts "→ Running #{config[:name]}..."
-        puts
-        stdout, status = run_subprocess(['ruby', worker_script], env: config[:env])
-        raise "#{config[:name]} benchmark failed" unless status.success?
-        puts
-        puts
-      end
-    end
-
-    # Combine results
-    combine_worker_results
-  end
-
-  private
-
-  def run_subprocess(command, env: {})
-    stdout_lines = []
-
-    Open3.popen3(env, *command) do |stdin, stdout, stderr, wait_thr|
-      stdin.close
-
-      # Stream output in real-time
-      threads = []
-
-      # Thread for stdout
-      threads << Thread.new do
-        stdout.each_line do |line|
-          puts line
-          stdout_lines << line
-        end
-      end
-
-      # Thread for stderr
-      threads << Thread.new do
-        stderr.each_line do |line|
-          warn "⚠️  #{line}"
-        end
-      end
-
-      # Wait for all output to be read
-      threads.each(&:join)
-
-      # Get exit status
-      status = wait_thr.value
-
-      return [stdout_lines.join, status]
-    end
-  end
-
-  def combine_worker_results
-    # Read all worker result files
-    all_results = read_worker_results('parsing_*.json')
-
-    # Combine into single result
-    combined = {
-      'name' => self.class.benchmark_name,
-      'description' => self.class.description,
-      'metadata' => self.class.metadata,
-      'results' => all_results
-    }
-
-    # Calculate speedups using configured strategy
-    require_relative 'speedup_calculator'
-    config = self.class.speedup_config
-    if config
-      calculator = SpeedupCalculator.new(
-        results: combined['results'],
-        test_cases: combined['metadata']['test_cases'],
-        baseline_matcher: config[:baseline_matcher],
-        comparison_matcher: config[:comparison_matcher],
-        test_case_key: config[:test_case_key]
-      )
-
-      speedup_stats = calculator.calculate
-      combined['metadata']['speedups'] = speedup_stats if speedup_stats
-    end
-
-    # Write combined results
-    combined_path = File.join(RESULTS_DIR, "#{self.class.benchmark_name}.json")
-    File.write(combined_path, JSON.pretty_generate(combined))
-
-    # Clean up worker files
-    cleanup_worker_results('parsing_*.json')
-
-    puts '=' * 80
-    puts '✓ All parsing benchmarks complete'
-    puts "Results saved to: #{combined_path}"
-    puts '=' * 80
+    announce_variants
+    run_all_variants(File.expand_path('benchmark_parsing_workers.rb', __dir__))
   end
 end
 

--- a/benchmarks/benchmark_parsing_workers.rb
+++ b/benchmarks/benchmark_parsing_workers.rb
@@ -7,68 +7,29 @@ require_relative 'worker_helpers'
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-# Worker benchmark: Cataract pure Ruby
-class ParsingCataractPureBenchmark < BenchmarkHarness
+# Measures CSS parsing for whichever configuration this process was launched
+# as. One class covers every variant: WorkerHelpers reads the backend and JIT
+# off the running VM and verifies them, so there is nothing per-variant to
+# subclass.
+class ParsingWorkerBenchmark < BenchmarkHarness
   include ParsingTests
   include WorkerHelpers
 
   def self.benchmark_name
-    'parsing_cataract_pure'
+    'parsing'
   end
 
   def self.description
-    'CSS parsing with Cataract pure Ruby'
+    'CSS parsing'
   end
 
   def self.metadata
     ParsingTests.metadata
   end
-
-  def self.speedup_config
-    ParsingTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type(:pure, ParsingTests)
-  end
 end
 
-# Worker benchmark: Cataract C extension
-class ParsingCataractNativeBenchmark < BenchmarkHarness
-  include ParsingTests
-  include WorkerHelpers
-
-  def self.benchmark_name
-    'parsing_cataract_native'
-  end
-
-  def self.description
-    'CSS parsing with Cataract C extension'
-  end
-
-  def self.metadata
-    ParsingTests.metadata
-  end
-
-  def self.speedup_config
-    ParsingTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type(:native, ParsingTests)
-  end
-end
-
-# CLI entry point - run the appropriate worker
+# CLI entry point
 if __FILE__ == $PROGRAM_NAME
-  # Load Cataract (will be pure or native depending on CATARACT_PURE)
   require 'cataract'
-
-  if Cataract::IMPLEMENTATION == :ruby
-    ParsingCataractPureBenchmark.run(skip_finalize: true)
-  else
-    ParsingCataractNativeBenchmark.run(skip_finalize: true)
-  end
+  ParsingWorkerBenchmark.run(skip_finalize: true)
 end

--- a/benchmarks/benchmark_parsing_workers.rb
+++ b/benchmarks/benchmark_parsing_workers.rb
@@ -30,7 +30,7 @@ class ParsingCataractPureBenchmark < BenchmarkHarness
 
   def initialize
     super
-    self.impl_type = determine_impl_type_with_yjit(:pure, ParsingTests)
+    self.impl_type = determine_impl_type(:pure, ParsingTests)
   end
 end
 
@@ -57,7 +57,7 @@ class ParsingCataractNativeBenchmark < BenchmarkHarness
 
   def initialize
     super
-    self.impl_type = determine_impl_type_with_yjit(:native, ParsingTests)
+    self.impl_type = determine_impl_type(:native, ParsingTests)
   end
 end
 

--- a/benchmarks/benchmark_serialization.rb
+++ b/benchmarks/benchmark_serialization.rb
@@ -49,7 +49,7 @@ class SerializationBenchmark < BenchmarkHarness
     Dir.glob(File.join(RESULTS_DIR, 'serialization_*.json')).each { |f| FileUtils.rm_f(f) }
 
     puts 'Running serialization benchmarks via subprocesses...'
-    puts 'Testing implementations with YJIT variations where applicable'
+    puts 'Testing implementations with JIT variations (none/YJIT/ZJIT) where applicable'
     puts
 
     # Define implementations to test - run via subprocess (see BenchmarkHarness
@@ -62,18 +62,32 @@ class SerializationBenchmark < BenchmarkHarness
 
     implementations.each do |config|
       if SerializationTests.yjit_applicable?(config[:base_impl])
-        # Run both YJIT variants
+        # Run all JIT variants. CATARACT_BENCH_JIT tells the worker which
+        # mode we intended (see WorkerHelpers#verify_jit_mode!) so it can
+        # raise loudly if the actual JIT active doesn't match - e.g. a Ruby
+        # build without YJIT/ZJIT support silently falling back to the
+        # interpreter instead of honoring --yjit/--zjit.
         puts "→ Running #{config[:name]} without YJIT..."
         puts
-        stdout, status = run_subprocess(['ruby', '--disable-yjit', worker_script], env: config[:env])
+        stdout, status = run_subprocess(['ruby', '--disable-yjit', worker_script],
+                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'none'))
         raise "#{config[:name]} (no YJIT) benchmark failed" unless status.success?
         puts
         puts
 
         puts "→ Running #{config[:name]} with YJIT..."
         puts
-        stdout, status = run_subprocess(['ruby', '--yjit', worker_script], env: config[:env])
+        stdout, status = run_subprocess(['ruby', '--yjit', worker_script],
+                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'yjit'))
         raise "#{config[:name]} (YJIT) benchmark failed" unless status.success?
+        puts
+        puts
+
+        puts "→ Running #{config[:name]} with ZJIT..."
+        puts
+        stdout, status = run_subprocess(['ruby', '--zjit', worker_script],
+                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'zjit'))
+        raise "#{config[:name]} (ZJIT) benchmark failed" unless status.success?
         puts
         puts
       else

--- a/benchmarks/benchmark_serialization.rb
+++ b/benchmarks/benchmark_serialization.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'benchmark_harness'
-require 'open3'
+require_relative 'serialization_tests'
 
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'cataract'
 
 # CSS Serialization Performance Benchmark
-# Compares Cataract pure Ruby vs Cataract C extension
+#
+# Orchestration only - one subprocess per Implementation. The measuring
+# happens in benchmark_serialization_workers.rb.
 class SerializationBenchmark < BenchmarkHarness
   def self.benchmark_name
     'serialization'
@@ -19,196 +21,22 @@ class SerializationBenchmark < BenchmarkHarness
   end
 
   def self.metadata
-    require_relative 'serialization_tests'
     SerializationTests.metadata
   end
 
-  def self.speedup_config
-    require_relative 'serialization_tests'
-    SerializationTests.speedup_config
-  end
-
   def sanity_checks
-    # Verify Bootstrap fixture exists
     bootstrap_path = File.expand_path('../test/fixtures/bootstrap.css', __dir__)
     raise "Bootstrap CSS fixture not found at #{bootstrap_path}" unless File.exist?(bootstrap_path)
 
     # Verify cataract works
-    bootstrap_css = File.read(bootstrap_path)
-    cataract_sheet = Cataract.parse_css(bootstrap_css)
+    cataract_sheet = Cataract.parse_css(File.read(bootstrap_path))
     raise 'Cataract sanity check failed' if cataract_sheet.empty?
     raise 'Cataract serialization failed' if cataract_sheet.to_s.empty?
   end
 
   def call
-    require_relative 'serialization_tests'
-
-    worker_script = File.expand_path('benchmark_serialization_workers.rb', __dir__)
-
-    # Clean up any leftover worker files from previous runs
-    Dir.glob(File.join(RESULTS_DIR, 'serialization_*.json')).each { |f| FileUtils.rm_f(f) }
-
-    puts 'Running serialization benchmarks via subprocesses...'
-    puts 'Testing implementations with JIT variations (none/YJIT/ZJIT) where applicable'
-    puts
-
-    # Define implementations to test - run via subprocess (see BenchmarkHarness
-    # for why: in-process comparison measurably distorts pure Ruby's numbers
-    # under YJIT).
-    implementations = [
-      { name: 'Cataract pure Ruby', base_impl: :pure, env: { 'CATARACT_PURE' => '1' } },
-      { name: 'Cataract C extension', base_impl: :native, env: { 'CATARACT_PURE' => nil } }
-    ]
-
-    implementations.each do |config|
-      if SerializationTests.yjit_applicable?(config[:base_impl])
-        # Run all JIT variants. CATARACT_BENCH_JIT tells the worker which
-        # mode we intended (see WorkerHelpers#verify_jit_mode!) so it can
-        # raise loudly if the actual JIT active doesn't match - e.g. a Ruby
-        # build without YJIT/ZJIT support silently falling back to the
-        # interpreter instead of honoring --yjit/--zjit.
-        puts "→ Running #{config[:name]} without YJIT..."
-        puts
-        stdout, status = run_subprocess(['ruby', '--disable-yjit', worker_script],
-                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'none'))
-        raise "#{config[:name]} (no YJIT) benchmark failed" unless status.success?
-        puts
-        puts
-
-        puts "→ Running #{config[:name]} with YJIT..."
-        puts
-        stdout, status = run_subprocess(['ruby', '--yjit', worker_script],
-                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'yjit'))
-        raise "#{config[:name]} (YJIT) benchmark failed" unless status.success?
-        puts
-        puts
-
-        puts "→ Running #{config[:name]} with ZJIT..."
-        puts
-        stdout, status = run_subprocess(['ruby', '--zjit', worker_script],
-                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'zjit'))
-        raise "#{config[:name]} (ZJIT) benchmark failed" unless status.success?
-        puts
-        puts
-      else
-        # Run without YJIT flags (YJIT not applicable)
-        puts "→ Running #{config[:name]}..."
-        puts
-        stdout, status = run_subprocess(['ruby', worker_script], env: config[:env])
-        raise "#{config[:name]} benchmark failed" unless status.success?
-        puts
-        puts
-      end
-    end
-
-    # Combine results
-    combine_worker_results
-
-    # Show correctness comparison
-    show_correctness_comparison
-  end
-
-  private
-
-  def run_subprocess(command, env: {})
-    stdout_lines = []
-
-    Open3.popen3(env, *command) do |stdin, stdout, stderr, wait_thr|
-      stdin.close
-
-      # Stream output in real-time
-      threads = []
-
-      # Thread for stdout
-      threads << Thread.new do
-        stdout.each_line do |line|
-          puts line
-          stdout_lines << line
-        end
-      end
-
-      # Thread for stderr
-      threads << Thread.new do
-        stderr.each_line do |line|
-          warn "⚠️  #{line}"
-        end
-      end
-
-      # Wait for all output to be read
-      threads.each(&:join)
-
-      # Get exit status
-      status = wait_thr.value
-
-      return [stdout_lines.join, status]
-    end
-  end
-
-  def combine_worker_results
-    # Read all worker result files
-    all_results = read_worker_results('serialization_*.json')
-
-    # Combine into single result
-    combined = {
-      'name' => self.class.benchmark_name,
-      'description' => self.class.description,
-      'metadata' => self.class.metadata,
-      'results' => all_results
-    }
-
-    # Calculate speedups using configured strategy
-    require_relative 'speedup_calculator'
-    config = self.class.speedup_config
-    if config
-      calculator = SpeedupCalculator.new(
-        results: combined['results'],
-        test_cases: combined['metadata']['test_cases'],
-        baseline_matcher: config[:baseline_matcher],
-        comparison_matcher: config[:comparison_matcher],
-        test_case_key: config[:test_case_key]
-      )
-
-      speedup_stats = calculator.calculate
-      combined['metadata']['speedups'] = speedup_stats if speedup_stats
-    end
-
-    # Write combined results
-    combined_path = File.join(RESULTS_DIR, "#{self.class.benchmark_name}.json")
-    File.write(combined_path, JSON.pretty_generate(combined))
-
-    # Clean up worker files
-    cleanup_worker_results('serialization_*.json')
-
-    puts '=' * 80
-    puts '✓ All serialization benchmarks complete'
-    puts "Results saved to: #{combined_path}"
-    puts '=' * 80
-  end
-
-  def show_correctness_comparison
-    puts "\n#{'=' * 80}"
-    puts 'CORRECTNESS VALIDATION'
-    puts '=' * 80
-
-    bootstrap_path = File.expand_path('../test/fixtures/bootstrap.css', __dir__)
-    bootstrap_css = File.read(bootstrap_path)
-
-    puts "Input: Bootstrap CSS (#{bootstrap_css.length} bytes)"
-
-    # Parse and serialize
-    cataract_sheet = Cataract.parse_css(bootstrap_css)
-    cataract_output = cataract_sheet.to_s
-
-    puts "Cataract output: #{cataract_output.length} bytes (#{cataract_sheet.size} rules)"
-
-    # Check that output can be re-parsed
-    begin
-      reparsed = Cataract.parse_css(cataract_output)
-      puts "Re-parsed output: #{reparsed.size} rules"
-    rescue StandardError => e
-      puts "❌ Failed to re-parse: #{e.message}"
-      raise
-    end
+    announce_variants
+    run_all_variants(File.expand_path('benchmark_serialization_workers.rb', __dir__))
   end
 end
 

--- a/benchmarks/benchmark_serialization_workers.rb
+++ b/benchmarks/benchmark_serialization_workers.rb
@@ -7,67 +7,29 @@ require_relative 'worker_helpers'
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-# Worker benchmark: Cataract pure Ruby
-class SerializationCataractPureBenchmark < BenchmarkHarness
+# Measures CSS serialization for whichever configuration this process was
+# launched as. One class covers every variant: WorkerHelpers reads the
+# backend and JIT off the running VM and verifies them, so there is nothing
+# per-variant to subclass.
+class SerializationWorkerBenchmark < BenchmarkHarness
   include SerializationTests
   include WorkerHelpers
 
   def self.benchmark_name
-    'serialization_cataract_pure'
+    'serialization'
   end
 
   def self.description
-    'CSS serialization with Cataract pure Ruby'
+    'CSS serialization'
   end
 
   def self.metadata
     SerializationTests.metadata
   end
-
-  def self.speedup_config
-    SerializationTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type(:pure, SerializationTests)
-  end
 end
 
-# Worker benchmark: Cataract C extension
-class SerializationCataractNativeBenchmark < BenchmarkHarness
-  include SerializationTests
-  include WorkerHelpers
-
-  def self.benchmark_name
-    'serialization_cataract_native'
-  end
-
-  def self.description
-    'CSS serialization with Cataract C extension'
-  end
-
-  def self.metadata
-    SerializationTests.metadata
-  end
-
-  def self.speedup_config
-    SerializationTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type(:native, SerializationTests)
-  end
-end
-
-# CLI entry point - run the appropriate worker
+# CLI entry point
 if __FILE__ == $PROGRAM_NAME
   require 'cataract'
-
-  if Cataract::IMPLEMENTATION == :ruby
-    SerializationCataractPureBenchmark.run(skip_finalize: true)
-  else
-    SerializationCataractNativeBenchmark.run(skip_finalize: true)
-  end
+  SerializationWorkerBenchmark.run(skip_finalize: true)
 end

--- a/benchmarks/benchmark_serialization_workers.rb
+++ b/benchmarks/benchmark_serialization_workers.rb
@@ -30,7 +30,7 @@ class SerializationCataractPureBenchmark < BenchmarkHarness
 
   def initialize
     super
-    self.impl_type = determine_impl_type_with_yjit(:pure, SerializationTests)
+    self.impl_type = determine_impl_type(:pure, SerializationTests)
   end
 end
 
@@ -57,7 +57,7 @@ class SerializationCataractNativeBenchmark < BenchmarkHarness
 
   def initialize
     super
-    self.impl_type = determine_impl_type_with_yjit(:native, SerializationTests)
+    self.impl_type = determine_impl_type(:native, SerializationTests)
   end
 end
 

--- a/benchmarks/benchmark_specificity.rb
+++ b/benchmarks/benchmark_specificity.rb
@@ -46,7 +46,7 @@ class SpecificityBenchmark < BenchmarkHarness
     Dir.glob(File.join(RESULTS_DIR, 'specificity_*.json')).each { |f| FileUtils.rm_f(f) }
 
     puts 'Running specificity benchmarks via subprocesses...'
-    puts 'Testing implementations with YJIT variations where applicable'
+    puts 'Testing implementations with JIT variations (none/YJIT/ZJIT) where applicable'
     puts
 
     # Define implementations to test - run via subprocess (see BenchmarkHarness
@@ -59,18 +59,32 @@ class SpecificityBenchmark < BenchmarkHarness
 
     implementations.each do |config|
       if SpecificityTests.yjit_applicable?(config[:base_impl])
-        # Run both YJIT variants
+        # Run all JIT variants. CATARACT_BENCH_JIT tells the worker which
+        # mode we intended (see WorkerHelpers#verify_jit_mode!) so it can
+        # raise loudly if the actual JIT active doesn't match - e.g. a Ruby
+        # build without YJIT/ZJIT support silently falling back to the
+        # interpreter instead of honoring --yjit/--zjit.
         puts "→ Running #{config[:name]} without YJIT..."
         puts
-        stdout, status = run_subprocess(['ruby', '--disable-yjit', worker_script], env: config[:env])
+        stdout, status = run_subprocess(['ruby', '--disable-yjit', worker_script],
+                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'none'))
         raise "#{config[:name]} (no YJIT) benchmark failed" unless status.success?
         puts
         puts
 
         puts "→ Running #{config[:name]} with YJIT..."
         puts
-        stdout, status = run_subprocess(['ruby', '--yjit', worker_script], env: config[:env])
+        stdout, status = run_subprocess(['ruby', '--yjit', worker_script],
+                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'yjit'))
         raise "#{config[:name]} (YJIT) benchmark failed" unless status.success?
+        puts
+        puts
+
+        puts "→ Running #{config[:name]} with ZJIT..."
+        puts
+        stdout, status = run_subprocess(['ruby', '--zjit', worker_script],
+                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'zjit'))
+        raise "#{config[:name]} (ZJIT) benchmark failed" unless status.success?
         puts
         puts
       else

--- a/benchmarks/benchmark_specificity.rb
+++ b/benchmarks/benchmark_specificity.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'benchmark_harness'
-require 'open3'
+require_relative 'specificity_tests'
 
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'cataract'
 
 # CSS Specificity Calculation Benchmark
-# Compares Cataract pure Ruby vs Cataract C extension
+#
+# Orchestration only - one subprocess per Implementation. The measuring
+# happens in benchmark_specificity_workers.rb.
 class SpecificityBenchmark < BenchmarkHarness
   def self.benchmark_name
     'specificity'
@@ -19,164 +21,21 @@ class SpecificityBenchmark < BenchmarkHarness
   end
 
   def self.metadata
-    require_relative 'specificity_tests'
     SpecificityTests.metadata
   end
 
-  def self.speedup_config
-    require_relative 'specificity_tests'
-    SpecificityTests.speedup_config
-  end
-
   def sanity_checks
-    # Verify both libraries work. calculate_specificity isn't public API - go
-    # through Rule#specificity like a real caller would. A fresh Rule each
-    # time means specificity is nil, so #specificity always calculates for
-    # real rather than returning a memoized value.
+    # calculate_specificity isn't public API - go through Rule#specificity
+    # like a real caller would. A fresh Rule each time means specificity is
+    # nil, so #specificity always calculates for real rather than returning a
+    # memoized value.
     rule = Cataract::Rule.make(id: 0, selector: 'div', declarations: [])
     raise 'Cataract sanity check failed' unless rule.specificity == 1
   end
 
   def call
-    require_relative 'specificity_tests'
-
-    worker_script = File.expand_path('benchmark_specificity_workers.rb', __dir__)
-
-    # Clean up any leftover worker files from previous runs
-    Dir.glob(File.join(RESULTS_DIR, 'specificity_*.json')).each { |f| FileUtils.rm_f(f) }
-
-    puts 'Running specificity benchmarks via subprocesses...'
-    puts 'Testing implementations with JIT variations (none/YJIT/ZJIT) where applicable'
-    puts
-
-    # Define implementations to test - run via subprocess (see BenchmarkHarness
-    # for why: in-process comparison measurably distorts pure Ruby's numbers
-    # under YJIT).
-    implementations = [
-      { name: 'Cataract pure Ruby', base_impl: :pure, env: { 'CATARACT_PURE' => '1' } },
-      { name: 'Cataract C extension', base_impl: :native, env: { 'CATARACT_PURE' => nil } }
-    ]
-
-    implementations.each do |config|
-      if SpecificityTests.yjit_applicable?(config[:base_impl])
-        # Run all JIT variants. CATARACT_BENCH_JIT tells the worker which
-        # mode we intended (see WorkerHelpers#verify_jit_mode!) so it can
-        # raise loudly if the actual JIT active doesn't match - e.g. a Ruby
-        # build without YJIT/ZJIT support silently falling back to the
-        # interpreter instead of honoring --yjit/--zjit.
-        puts "→ Running #{config[:name]} without YJIT..."
-        puts
-        stdout, status = run_subprocess(['ruby', '--disable-yjit', worker_script],
-                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'none'))
-        raise "#{config[:name]} (no YJIT) benchmark failed" unless status.success?
-        puts
-        puts
-
-        puts "→ Running #{config[:name]} with YJIT..."
-        puts
-        stdout, status = run_subprocess(['ruby', '--yjit', worker_script],
-                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'yjit'))
-        raise "#{config[:name]} (YJIT) benchmark failed" unless status.success?
-        puts
-        puts
-
-        puts "→ Running #{config[:name]} with ZJIT..."
-        puts
-        stdout, status = run_subprocess(['ruby', '--zjit', worker_script],
-                                        env: config[:env].merge('CATARACT_BENCH_JIT' => 'zjit'))
-        raise "#{config[:name]} (ZJIT) benchmark failed" unless status.success?
-        puts
-        puts
-      else
-        # Run without YJIT flags (YJIT not applicable)
-        puts "→ Running #{config[:name]}..."
-        puts
-        stdout, status = run_subprocess(['ruby', worker_script], env: config[:env])
-        raise "#{config[:name]} benchmark failed" unless status.success?
-        puts
-        puts
-      end
-    end
-
-    # Combine results
-    combine_worker_results
-  end
-
-  private
-
-  def run_subprocess(command, env: {})
-    stdout_lines = []
-
-    Open3.popen3(env, *command) do |stdin, stdout, stderr, wait_thr|
-      stdin.close
-
-      # Stream output in real-time
-      threads = []
-
-      # Thread for stdout
-      threads << Thread.new do
-        stdout.each_line do |line|
-          puts line
-          stdout_lines << line
-        end
-      end
-
-      # Thread for stderr
-      threads << Thread.new do
-        stderr.each_line do |line|
-          warn "⚠️  #{line}"
-        end
-      end
-
-      # Wait for all output to be read
-      threads.each(&:join)
-
-      # Get exit status
-      status = wait_thr.value
-
-      return [stdout_lines.join, status]
-    end
-  end
-
-  def combine_worker_results
-    # Read all worker result files
-    all_results = read_worker_results('specificity_*.json')
-
-    # Combine into single result
-    combined = {
-      'name' => self.class.benchmark_name,
-      'description' => self.class.description,
-      'metadata' => self.class.metadata,
-      'results' => all_results
-    }
-
-    # Calculate speedups using configured strategy
-    require_relative 'speedup_calculator'
-    config = self.class.speedup_config
-    if config
-      calculator = SpeedupCalculator.new(
-        results: combined['results'],
-        test_cases: combined['metadata']['test_cases'],
-        baseline_matcher: config[:baseline_matcher],
-        comparison_matcher: config[:comparison_matcher],
-        test_case_key: config[:test_case_key]
-      )
-
-      speedup_stats = calculator.calculate
-      combined['metadata']['speedups'] = speedup_stats if speedup_stats
-    end
-
-    # Write combined results
-    combined_path = File.join(RESULTS_DIR, "#{self.class.benchmark_name}.json")
-    File.write(combined_path, JSON.pretty_generate(combined))
-
-    # Clean up worker files
-    cleanup_worker_results('specificity_*.json')
-
-    puts '=' * 80
-    puts '✓ All specificity benchmarks complete'
-    puts "Results saved to: #{combined_path}"
-    puts '=' * 80
+    announce_variants
+    run_all_variants(File.expand_path('benchmark_specificity_workers.rb', __dir__))
   end
 end
 

--- a/benchmarks/benchmark_specificity_workers.rb
+++ b/benchmarks/benchmark_specificity_workers.rb
@@ -7,67 +7,29 @@ require_relative 'worker_helpers'
 # Load the local development version, not installed gem
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-# Worker benchmark: Cataract pure Ruby
-class SpecificityCataractPureBenchmark < BenchmarkHarness
+# Measures specificity calculation for whichever configuration this process
+# was launched as. One class covers every variant: WorkerHelpers reads the
+# backend and JIT off the running VM and verifies them, so there is nothing
+# per-variant to subclass.
+class SpecificityWorkerBenchmark < BenchmarkHarness
   include SpecificityTests
   include WorkerHelpers
 
   def self.benchmark_name
-    'specificity_cataract_pure'
+    'specificity'
   end
 
   def self.description
-    'CSS specificity calculation with Cataract pure Ruby'
+    'CSS selector specificity calculation'
   end
 
   def self.metadata
     SpecificityTests.metadata
   end
-
-  def self.speedup_config
-    SpecificityTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type(:pure, SpecificityTests)
-  end
 end
 
-# Worker benchmark: Cataract C extension
-class SpecificityCataractNativeBenchmark < BenchmarkHarness
-  include SpecificityTests
-  include WorkerHelpers
-
-  def self.benchmark_name
-    'specificity_cataract_native'
-  end
-
-  def self.description
-    'CSS specificity calculation with Cataract C extension'
-  end
-
-  def self.metadata
-    SpecificityTests.metadata
-  end
-
-  def self.speedup_config
-    SpecificityTests.speedup_config
-  end
-
-  def initialize
-    super
-    self.impl_type = determine_impl_type(:native, SpecificityTests)
-  end
-end
-
-# CLI entry point - run the appropriate worker
+# CLI entry point
 if __FILE__ == $PROGRAM_NAME
   require 'cataract'
-
-  if Cataract::IMPLEMENTATION == :ruby
-    SpecificityCataractPureBenchmark.run(skip_finalize: true)
-  else
-    SpecificityCataractNativeBenchmark.run(skip_finalize: true)
-  end
+  SpecificityWorkerBenchmark.run(skip_finalize: true)
 end

--- a/benchmarks/benchmark_specificity_workers.rb
+++ b/benchmarks/benchmark_specificity_workers.rb
@@ -30,7 +30,7 @@ class SpecificityCataractPureBenchmark < BenchmarkHarness
 
   def initialize
     super
-    self.impl_type = determine_impl_type_with_yjit(:pure, SpecificityTests)
+    self.impl_type = determine_impl_type(:pure, SpecificityTests)
   end
 end
 
@@ -57,7 +57,7 @@ class SpecificityCataractNativeBenchmark < BenchmarkHarness
 
   def initialize
     super
-    self.impl_type = determine_impl_type_with_yjit(:native, SpecificityTests)
+    self.impl_type = determine_impl_type(:native, SpecificityTests)
   end
 end
 

--- a/benchmarks/flattening_tests.rb
+++ b/benchmarks/flattening_tests.rb
@@ -4,7 +4,7 @@
 module FlatteningTests
   # Determines if YJIT testing is applicable for a given implementation
   def self.yjit_applicable?(impl_type)
-    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit/, '').to_sym
+    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
     base_impl != :native
   end
 
@@ -58,7 +58,7 @@ module FlatteningTests
   attr_accessor :impl_type
 
   def base_impl_type
-    impl_type.to_s.sub(/_with_yjit|_without_yjit/, '').to_sym
+    impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
   end
 
   def sanity_checks
@@ -93,7 +93,11 @@ module FlatteningTests
                  end
 
     yjit_suffix = if FlatteningTests.yjit_applicable?(impl_type)
-                    impl_type.to_s.include?('with_yjit') ? ' (YJIT)' : ' (no YJIT)'
+                    case impl_type.to_s
+                    when /with_yjit/ then ' (YJIT)'
+                    when /with_zjit/ then ' (ZJIT)'
+                    else ' (no YJIT)'
+                    end
                   else
                     ''
                   end

--- a/benchmarks/flattening_tests.rb
+++ b/benchmarks/flattening_tests.rb
@@ -2,67 +2,45 @@
 
 # Shared test definitions for flattening benchmarks
 module FlatteningTests
-  # Determines if YJIT testing is applicable for a given implementation
-  def self.yjit_applicable?(impl_type)
-    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
-    base_impl != :native
-  end
-
   def self.metadata
     {
       'test_cases' => [
         {
           'name' => 'No shorthand properties (large)',
-          'key' => 'no_shorthand',
+          'id' => 'no_shorthand',
           'css' => (".test { color: red; background-color: blue; display: block; position: relative; width: 100px; height: 50px; }\n" * 100)
         },
         {
           'name' => 'Simple properties',
-          'key' => 'simple',
+          'id' => 'simple',
           'css' => ".test { color: black; margin: 10px; }\n.test { padding: 5px; }"
         },
         {
           'name' => 'Cascade with specificity',
-          'key' => 'cascade',
+          'id' => 'cascade',
           'css' => ".test { color: black; }\n#test { color: red; }\n.test { margin: 10px; }"
         },
         {
           'name' => 'Important declarations',
-          'key' => 'important',
+          'id' => 'important',
           'css' => ".test { color: black !important; }\n#test { color: red; }\n.test { margin: 10px; }"
         },
         {
           'name' => 'Shorthand expansion',
-          'key' => 'shorthand',
+          'id' => 'shorthand',
           'css' => ".test { margin: 10px 20px; }\n.test { margin-left: 5px; }\n.test { padding: 1em 2em 3em 4em; }"
         },
         {
           'name' => 'Complex flattening',
-          'key' => 'complex',
+          'id' => 'complex',
           'css' => "body { margin: 0; padding: 0; }\n.container { width: 100%; margin: 0 auto; }\n#main { background: white; color: black; }\n.button { padding: 10px 20px; border: 1px solid #ccc; }\n.button:hover { background: #f0f0f0; }\n.button.primary { background: blue !important; color: white; }"
         }
       ]
     }
   end
 
-  def self.speedup_config
-    # Compare cataract pure without YJIT (baseline) vs cataract native (comparison)
-    {
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-      test_case_key: :key
-    }
-  end
-
-  # Must be set by including class before calling methods
-  attr_accessor :impl_type
-
-  def base_impl_type
-    impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
-  end
-
   def sanity_checks
-    case base_impl_type
+    case implementation.backend.id
     when :pure, :native
       # Verify flattening works correctly with Cataract
       css = ".test { color: black; }\n.test { margin: 10px; }"
@@ -84,54 +62,22 @@ module FlatteningTests
 
   private
 
-  def implementation_label
-    base_label = case base_impl_type
-                 when :pure
-                   'cataract pure'
-                 when :native
-                   'cataract'
-                 end
-
-    yjit_suffix = if FlatteningTests.yjit_applicable?(impl_type)
-                    case impl_type.to_s
-                    when /with_yjit/ then ' (YJIT)'
-                    when /with_zjit/ then ' (ZJIT)'
-                    else ' (no YJIT)'
-                    end
-                  else
-                    ''
-                  end
-
-    "#{base_label}#{yjit_suffix}"
-  end
-
   def benchmark_test_case(test_case)
     puts '=' * 80
-    puts "TEST: #{test_case['name']} - #{implementation_label}"
+    puts "TEST: #{test_case['name']} - #{implementation.label}"
     puts '=' * 80
 
-    key = test_case['key']
-    css = test_case['css']
+    id = test_case['id']
 
-    benchmark(key) do |x|
+    # Both backends run identical code; which one is exercised was decided
+    # when `require 'cataract'` picked a backend.
+    benchmark(id) do |x|
       x.config(time: 5, warmup: 2)
 
-      case base_impl_type
-      when :pure
-        # Cataract pure Ruby
-        cataract_rules = Cataract.parse_css(css)
+      cataract_rules = Cataract.parse_css(test_case['css'])
 
-        x.report("cataract pure: #{key}") do
-          Cataract.flatten(cataract_rules)
-        end
-
-      when :native
-        # Cataract C extension
-        cataract_rules = Cataract.parse_css(css)
-
-        x.report("cataract: #{key}") do
-          Cataract.flatten(cataract_rules)
-        end
+      x.report(result_name(id)) do
+        Cataract.flatten(cataract_rules)
       end
     end
   end

--- a/benchmarks/implementation.rb
+++ b/benchmarks/implementation.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require_relative 'backend'
+require_relative 'ruby_mode'
+
+# One benchmarked configuration: a Backend paired with the RubyMode it runs
+# under.
+#
+# Orchestrators launch one subprocess per Implementation, workers stamp their
+# results with the one they ran as, and BENCHMARKS.md renders one column per
+# Implementation. The two axes are carried separately through results, so
+# nothing downstream takes an id apart to recover them.
+class Implementation
+  attr_reader :backend, :mode
+
+  def initialize(backend:, mode:)
+    @backend = backend
+    @mode = mode
+    freeze
+  end
+
+  # Every backend crossed with the modes it declares.
+  def self.all
+    Backend::ALL.flat_map do |backend|
+      backend.modes.map { |mode| new(backend: backend, mode: mode) }
+    end
+  end
+
+  def self.find(backend_id, mode_id)
+    new(backend: Backend.fetch(backend_id), mode: RubyMode.fetch(mode_id))
+  end
+
+  # What a process is running as, verified on both axes against what was
+  # asked for. Raises rather than return a mislabeled configuration.
+  #
+  # The only place the ambient facts are read; everything below takes them as
+  # values.
+  def self.current(env: ENV, backend: Backend.active, mode: RubyMode.active)
+    new(
+      backend: Backend.verify!(actual: backend, expected: Backend.expected(env)),
+      mode: RubyMode.verify!(actual: mode, expected: RubyMode.expected(env))
+    )
+  end
+
+  # Identifier for result filenames and for matching a result to its column.
+  def id
+    :"#{backend.id}_#{mode.id}"
+  end
+
+  # Console label, e.g. "cataract pure (ZJIT)".
+  def label
+    qualify(backend.label, mode.label)
+  end
+
+  # BENCHMARKS.md column heading, e.g. "Pure (ZJIT)".
+  def column_label
+    qualify(backend.column_label, mode.column_label)
+  end
+
+  def ruby_command(script)
+    ['ruby', *mode.cli_flags, script]
+  end
+
+  def env
+    backend.selection_env.merge(
+      Backend::ENV_VAR => backend.id.to_s,
+      RubyMode::ENV_VAR => mode.id.to_s
+    )
+  end
+
+  # Fields stamped onto every result row. `backend` and `jit` are what
+  # consumers filter on.
+  def result_fields
+    {
+      'implementation' => id.to_s,
+      'backend' => backend.id.to_s,
+      'jit' => mode.id.to_s
+    }
+  end
+
+  # Whether the given result row came from this implementation.
+  def produced?(result)
+    result['implementation'] == id.to_s
+  end
+
+  def ==(other)
+    other.is_a?(Implementation) && other.backend == backend && other.mode == mode
+  end
+  alias eql? ==
+
+  def hash
+    [backend, mode].hash
+  end
+
+  def to_s
+    label
+  end
+
+  private
+
+  # Appends the mode only when the backend runs under more than one.
+  def qualify(base, suffix)
+    backend.modes.one? ? base : "#{base} (#{suffix})"
+  end
+end

--- a/benchmarks/implementation.rb
+++ b/benchmarks/implementation.rb
@@ -26,6 +26,13 @@ class Implementation
     end
   end
 
+  # Those the running Ruby can actually execute. Drives both the benchmark run
+  # and the BENCHMARKS.md columns, so a Ruby without ZJIT reports three
+  # columns rather than failing on `ruby --zjit`.
+  def self.available(ruby_vm = RubyVM)
+    all.select { |implementation| implementation.mode.available?(ruby_vm) }
+  end
+
   def self.find(backend_id, mode_id)
     new(backend: Backend.fetch(backend_id), mode: RubyMode.fetch(mode_id))
   end

--- a/benchmarks/parsing_tests.rb
+++ b/benchmarks/parsing_tests.rb
@@ -2,12 +2,6 @@
 
 # Shared test definitions for parsing benchmarks
 module ParsingTests
-  # Determines if YJIT testing is applicable for a given implementation
-  def self.yjit_applicable?(impl_type)
-    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
-    base_impl != :native
-  end
-
   def self.metadata
     # Create a temporary instance to access fixture data
     instance = Class.new do
@@ -33,19 +27,19 @@ module ParsingTests
       'test_cases' => [
         {
           'name' => "Small CSS (#{instance.css1.lines.count} lines, #{(instance.css1.length / 1024.0).round(1)}KB)",
-          'fixture' => 'small',
+          'id' => 'small',
           'lines' => instance.css1.lines.count,
           'bytes' => instance.css1.length
         },
         {
           'name' => "Medium CSS with @media (#{instance.css2.lines.count} lines, #{(instance.css2.length / 1024.0).round(1)}KB)",
-          'fixture' => 'medium with @media',
+          'id' => 'medium with @media',
           'lines' => instance.css2.lines.count,
           'bytes' => instance.css2.length
         },
         {
           'name' => "Selector lists (#{instance.selector_lists_css.lines.count} lines, #{(instance.selector_lists_css.length / 1024.0).round(1)}KB, 500 lists)",
-          'fixture' => 'selector lists',
+          'id' => 'selector lists',
           'lines' => instance.selector_lists_css.lines.count,
           'bytes' => instance.selector_lists_css.length
         }
@@ -53,31 +47,18 @@ module ParsingTests
       'error_checking' => [
         {
           'name' => "Medium CSS (#{instance.css2.lines.count} lines) - no error checking",
-          'key' => 'error_checking_off'
+          'id' => 'error checking off'
         },
         {
           'name' => "Medium CSS (#{instance.css2.lines.count} lines) - with error checking",
-          'key' => 'error_checking_on'
+          'id' => 'error checking on'
         }
       ]
     }
   end
 
-  def self.speedup_config
-    # Compare cataract pure without YJIT (baseline) vs cataract native (comparison)
-    # For fair comparison, compare both without YJIT optimizations
-    {
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-      test_case_key: :fixture
-    }
-  end
-
-  # Must be set by including class before calling methods
-  attr_accessor :impl_type
-
   def sanity_checks
-    case base_impl_type
+    case implementation.backend.id
     when :pure, :native
       # Verify fixtures parse correctly with Cataract
       parser = Cataract::Stylesheet.new
@@ -88,10 +69,6 @@ module ParsingTests
       parser.add_block(css2)
       raise 'CSS2 sanity check failed: expected rules' if parser.rules_count.zero?
     end
-  end
-
-  def base_impl_type
-    impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
   end
 
   def call
@@ -119,91 +96,56 @@ module ParsingTests
     @fixtures_dir ||= File.expand_path('../test/fixtures', __dir__)
   end
 
-  def implementation_label
-    base_label = case base_impl_type
-                 when :pure
-                   'cataract pure'
-                 when :native
-                   'cataract'
-                 end
-
-    yjit_suffix = if ParsingTests.yjit_applicable?(impl_type)
-                    case impl_type.to_s
-                    when /with_yjit/ then ' (YJIT)'
-                    when /with_zjit/ then ' (ZJIT)'
-                    else ' (no YJIT)'
-                    end
-                  else
-                    ''
-                  end
-
-    "#{base_label}#{yjit_suffix}"
-  end
+  # Both backends run identical code below; which one is exercised was
+  # decided when `require 'cataract'` picked a backend.
 
   def run_css1_benchmark
     puts '=' * 80
-    puts "TEST: Small CSS (#{css1.lines.count} lines, #{css1.length} chars) - #{implementation_label}"
+    puts "TEST: Small CSS (#{css1.lines.count} lines, #{css1.length} chars) - #{implementation.label}"
     puts '=' * 80
 
     benchmark('css1') do |x|
       x.config(time: 5, warmup: 2)
 
-      case base_impl_type
-      when :pure
-        x.report('cataract pure: small') do
-          parser = Cataract::Stylesheet.new
-          parser.add_block(css1)
-        end
-      when :native
-        x.report('cataract: small') do
-          parser = Cataract::Stylesheet.new
-          parser.add_block(css1)
-        end
+      x.report(result_name('small')) do
+        parser = Cataract::Stylesheet.new
+        parser.add_block(css1)
       end
     end
   end
 
   def run_css2_benchmark
     puts "\n#{'=' * 80}"
-    puts "TEST: Medium CSS with @media (#{css2.lines.count} lines, #{css2.length} chars) - #{implementation_label}"
+    puts "TEST: Medium CSS with @media (#{css2.lines.count} lines, #{css2.length} chars) - #{implementation.label}"
     puts '=' * 80
 
     benchmark('css2') do |x|
       x.config(time: 5, warmup: 2)
 
-      case base_impl_type
-      when :pure
-        x.report('cataract pure: medium with @media') do
-          parser = Cataract::Stylesheet.new
-          parser.add_block(css2)
-        end
-      when :native
-        x.report('cataract: medium with @media') do
-          parser = Cataract::Stylesheet.new
-          parser.add_block(css2)
-        end
+      x.report(result_name('medium with @media')) do
+        parser = Cataract::Stylesheet.new
+        parser.add_block(css2)
       end
     end
   end
 
   def run_selector_lists_benchmark
     puts "\n#{'=' * 80}"
-    puts "TEST: Selector lists (#{selector_lists_css.lines.count} lines, #{selector_lists_css.length} chars) - #{implementation_label}"
+    puts "TEST: Selector lists (#{selector_lists_css.lines.count} lines, #{selector_lists_css.length} chars) - " \
+         "#{implementation.label}"
     puts '=' * 80
 
     benchmark('selector_lists') do |x|
       x.config(time: 5, warmup: 2)
 
-      impl_label = base_impl_type == :pure ? 'cataract pure' : 'cataract'
-
       # Test WITH selector_lists enabled (default, feature overhead included)
-      x.report("#{impl_label}: selector lists") do
+      x.report(result_name('selector lists')) do
         parser = Cataract::Stylesheet.new(parser: { selector_lists: true })
         parser.add_block(selector_lists_css)
       end
 
       # Test WITHOUT selector_lists (baseline, no feature overhead)
-      x.report("#{impl_label}: selector lists (disabled)") do
+      x.report(result_name('selector lists (disabled)')) do
         parser = Cataract::Stylesheet.new(parser: { selector_lists: false })
         parser.add_block(selector_lists_css)
       end
@@ -214,22 +156,20 @@ module ParsingTests
 
   def run_error_checking_overhead_benchmark
     puts "\n#{'=' * 80}"
-    puts "TEST: Error Checking Overhead (#{css2.lines.count} lines, #{css2.length} chars) - #{implementation_label}"
+    puts "TEST: Error Checking Overhead (#{css2.lines.count} lines, #{css2.length} chars) - #{implementation.label}"
     puts '=' * 80
 
     benchmark('error_checking') do |x|
       x.config(time: 5, warmup: 2)
 
-      impl_label = base_impl_type == :pure ? 'cataract pure' : 'cataract'
-
       # Test WITHOUT error checking (baseline)
-      x.report("#{impl_label}: error checking off") do
+      x.report(result_name('error checking off')) do
         parser = Cataract::Stylesheet.new
         parser.add_block(css2)
       end
 
       # Test WITH error checking enabled (overhead)
-      x.report("#{impl_label}: error checking on") do
+      x.report(result_name('error checking on')) do
         parser = Cataract::Stylesheet.new(parser: { raise_parse_errors: true })
         parser.add_block(css2)
       end

--- a/benchmarks/parsing_tests.rb
+++ b/benchmarks/parsing_tests.rb
@@ -4,7 +4,7 @@
 module ParsingTests
   # Determines if YJIT testing is applicable for a given implementation
   def self.yjit_applicable?(impl_type)
-    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit/, '').to_sym
+    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
     base_impl != :native
   end
 
@@ -91,7 +91,7 @@ module ParsingTests
   end
 
   def base_impl_type
-    impl_type.to_s.sub(/_with_yjit|_without_yjit/, '').to_sym
+    impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
   end
 
   def call
@@ -128,7 +128,11 @@ module ParsingTests
                  end
 
     yjit_suffix = if ParsingTests.yjit_applicable?(impl_type)
-                    impl_type.to_s.include?('with_yjit') ? ' (YJIT)' : ' (no YJIT)'
+                    case impl_type.to_s
+                    when /with_yjit/ then ' (YJIT)'
+                    when /with_zjit/ then ' (ZJIT)'
+                    else ' (no YJIT)'
+                    end
                   else
                     ''
                   end

--- a/benchmarks/result_set.rb
+++ b/benchmarks/result_set.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# The measurements from one benchmark, indexed for lookup by test case and
+# implementation.
+#
+# Lookup is by whole id, never substring: benchmark ids overlap ('shorthand'
+# and 'no_shorthand', 'compact' and 'bootstrap_compact'), and a substring
+# match returns a different test case's numbers.
+class ResultSet
+  # Result names follow "label: test_case_id".
+  def self.test_case_id(result)
+    result['name'].split(':').last.strip
+  end
+
+  attr_reader :rows
+
+  def initialize(rows)
+    @rows = rows || []
+    @index = @rows.to_h { |row| [[self.class.test_case_id(row), row['implementation']], row] }
+  end
+
+  # @param test_case_id [String] id from the benchmark's metadata
+  # @param implementation [Implementation]
+  # @return [Hash, nil] the measurement, or nil if that pairing wasn't run
+  def find(test_case_id, implementation)
+    @index[[test_case_id, implementation.id.to_s]]
+  end
+
+  # The given implementations that produced measurements here, in the order
+  # given. Lets a table omit columns nothing was measured for.
+  def implementations_among(candidates)
+    present = @rows.each_with_object({}) { |row, seen| seen[row['implementation']] = true }
+    candidates.select { |implementation| present.key?(implementation.id.to_s) }
+  end
+end

--- a/benchmarks/result_table.rb
+++ b/benchmarks/result_table.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative 'benchmark_formatting'
+require_relative 'result_set'
+
+# A markdown table of one measurement per test case per implementation.
+#
+# Headings and cells are read off the same Implementation objects, so a
+# column heading always names what produced its numbers.
+class ResultTable
+  include BenchmarkFormatting
+
+  # @param results [Array<Hash>] result rows for one benchmark
+  # @param test_cases [Array<Hash>] metadata entries, each with 'id' and 'name'
+  # @param implementations [Array<Implementation>] columns, in display order
+  # @param row_header [String] heading for the leftmost column
+  def initialize(results:, test_cases:, implementations:, row_header: 'Test Case')
+    @results = ResultSet.new(results)
+    @test_cases = test_cases || []
+    @implementations = @results.implementations_among(implementations)
+    @row_header = row_header
+  end
+
+  def to_markdown
+    return '' if @implementations.empty?
+
+    [heading_row, divider_row, *body_rows].join("\n")
+  end
+
+  private
+
+  def heading_row
+    row(@row_header, @implementations.map(&:column_label))
+  end
+
+  def divider_row
+    row('-' * @row_header.length, @implementations.map { |impl| '-' * impl.column_label.length })
+  end
+
+  def body_rows
+    @test_cases.map do |test_case|
+      cells = @implementations.map do |implementation|
+        format_ips(@results.find(test_case['id'], implementation), short: true)
+      end
+      row(test_case['name'], cells)
+    end
+  end
+
+  def row(first, rest)
+    "| #{[first, *rest].join(' | ')} |"
+  end
+end
+
+# A markdown table of what enabling a feature costs each implementation,
+# measured as the gap between two test cases of the same benchmark.
+class OverheadTable
+  include BenchmarkFormatting
+
+  # @param without_id [String] test case id measured with the feature off
+  # @param with_id [String] test case id measured with the feature on
+  def initialize(results:, implementations:, without_id:, with_id:)
+    @results = ResultSet.new(results)
+    @implementations = @results.implementations_among(implementations)
+    @without_id = without_id
+    @with_id = with_id
+  end
+
+  def to_markdown
+    rows = @implementations.filter_map do |implementation|
+      without = @results.find(@without_id, implementation)
+      with = @results.find(@with_id, implementation)
+      next unless without && with
+
+      "| #{implementation.column_label} | #{format_overhead(without, with)} |"
+    end
+    return '' if rows.empty?
+
+    ['| Implementation | Overhead |', '|----------------|----------|', *rows].join("\n")
+  end
+end

--- a/benchmarks/results_directory.rb
+++ b/benchmarks/results_directory.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+
+# The directory benchmark result JSON is written to and read back from.
+#
+# A value, passed explicitly, so a test can hand the harness a temp directory
+# without touching global state. The environment appears in exactly two
+# places - `from_env` reads a location sent by a parent process, `#env`
+# produces the entry to send one - because orchestrator and workers are
+# separate processes and have to agree on where results go.
+class ResultsDirectory
+  ENV_VAR = 'CATARACT_BENCH_RESULTS_DIR'
+  DEFAULT_PATH = File.expand_path('.results', __dir__)
+
+  # @param env [Hash] environment to read the location from
+  def self.from_env(env)
+    new(env[ENV_VAR] || DEFAULT_PATH)
+  end
+
+  attr_reader :path
+
+  def initialize(path)
+    @path = path
+    freeze
+  end
+
+  def join(filename)
+    File.join(path, filename)
+  end
+
+  def glob(pattern)
+    Dir.glob(File.join(path, pattern))
+  end
+
+  def create
+    FileUtils.mkdir_p(path)
+    self
+  end
+
+  def read(filename)
+    JSON.parse(File.read(join(filename)))
+  end
+
+  def write(filename, data)
+    File.write(join(filename), JSON.pretty_generate(data))
+  end
+
+  def exist?(filename)
+    File.exist?(join(filename))
+  end
+
+  def delete(pattern)
+    glob(pattern).each { |file| File.delete(file) }
+  end
+
+  # Entry handed to a worker subprocess so it writes alongside its parent.
+  def env
+    { ENV_VAR => path }
+  end
+
+  def ==(other)
+    other.is_a?(ResultsDirectory) && other.path == path
+  end
+  alias eql? ==
+
+  def hash
+    path.hash
+  end
+
+  def to_s
+    path
+  end
+end

--- a/benchmarks/ruby_mode.rb
+++ b/benchmarks/ruby_mode.rb
@@ -14,14 +14,16 @@ class RubyMode
 
   Mismatch = Class.new(StandardError)
 
-  attr_reader :id, :cli_flags, :label, :column_label
+  attr_reader :id, :cli_flags, :label, :column_label, :vm_constant
 
-  def initialize(id:, cli_flags:, label:, column_label:, detector:, stats_reader: ->(_vm) { {} })
+  def initialize(id:, cli_flags:, label:, column_label:, detector:, vm_constant: nil,
+                 stats_reader: ->(_vm) { {} })
     @id = id
     @cli_flags = cli_flags.freeze
     @label = label
     @column_label = column_label
     @detector = detector
+    @vm_constant = vm_constant
     @stats_reader = stats_reader
     freeze
   end
@@ -29,6 +31,13 @@ class RubyMode
   # Whether this is the mode active in the given VM.
   def active?(ruby_vm = RubyVM)
     @detector.call(ruby_vm)
+  end
+
+  # Whether this Ruby can run the mode at all. ZJIT arrived in Ruby 4.0 and
+  # YJIT can be left out of a build, so elsewhere the matching --flag is an
+  # error rather than a slower run.
+  def available?(ruby_vm = RubyVM)
+    vm_constant.nil? || ruby_vm.const_defined?(vm_constant)
   end
 
   # What the JIT compiled and what it cost, normalized to keys that mean the
@@ -73,6 +82,7 @@ class RubyMode
     cli_flags: %w[--yjit].freeze,
     label: 'YJIT',
     column_label: 'YJIT',
+    vm_constant: :YJIT,
     detector: ->(ruby_vm) { jit_enabled?(ruby_vm, :YJIT) },
     stats_reader: lambda { |ruby_vm|
       normalize_stats(ruby_vm.const_get(:YJIT).runtime_stats,
@@ -87,6 +97,7 @@ class RubyMode
     cli_flags: %w[--zjit].freeze,
     label: 'ZJIT',
     column_label: 'ZJIT',
+    vm_constant: :ZJIT,
     detector: ->(ruby_vm) { jit_enabled?(ruby_vm, :ZJIT) },
     stats_reader: lambda { |ruby_vm|
       normalize_stats(ruby_vm.const_get(:ZJIT).stats,

--- a/benchmarks/ruby_mode.rb
+++ b/benchmarks/ruby_mode.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+# One Ruby VM configuration a benchmark can run under: no JIT, YJIT, or ZJIT.
+#
+# Owns everything that varies by mode - the flags that launch it, how to
+# detect it in a running VM, its labels, and how to read its JIT statistics.
+# Adding a mode means adding one constant here.
+#
+# The VM and the environment are passed in rather than read globally, so
+# detection and verification are testable without a matching subprocess.
+class RubyMode
+  # Set by a parent process to declare which mode a worker should be in.
+  ENV_VAR = 'CATARACT_BENCH_JIT'
+
+  Mismatch = Class.new(StandardError)
+
+  attr_reader :id, :cli_flags, :label, :column_label
+
+  def initialize(id:, cli_flags:, label:, column_label:, detector:, stats_reader: ->(_vm) { {} })
+    @id = id
+    @cli_flags = cli_flags.freeze
+    @label = label
+    @column_label = column_label
+    @detector = detector
+    @stats_reader = stats_reader
+    freeze
+  end
+
+  # Whether this is the mode active in the given VM.
+  def active?(ruby_vm = RubyVM)
+    @detector.call(ruby_vm)
+  end
+
+  # What the JIT compiled and what it cost, normalized to keys that mean the
+  # same thing across JITs. Distinguishes a JIT that compiled the hot methods
+  # from one that bailed out and left the interpreter to do the work.
+  def stats(ruby_vm = RubyVM)
+    @stats_reader.call(ruby_vm)
+  end
+
+  def to_s
+    label
+  end
+
+  # Whether a JIT constant exists on the VM and reports itself enabled.
+  def self.jit_enabled?(ruby_vm, const_name)
+    return false unless ruby_vm.const_defined?(const_name)
+
+    jit = ruby_vm.const_get(const_name)
+    jit.respond_to?(:enabled?) && jit.enabled?
+  end
+
+  # Maps one JIT's stat names onto the four shared keys.
+  def self.normalize_stats(raw, compiled:, failed:, code_bytes:)
+    {
+      'compiled_iseq_count' => raw[compiled],
+      'failed_iseq_count' => raw[failed],
+      'compile_time_ns' => raw[:compile_time_ns],
+      'code_region_bytes' => raw[code_bytes]
+    }
+  end
+
+  NO_JIT = new(
+    id: :none,
+    cli_flags: %w[--disable-yjit].freeze,
+    label: 'no JIT',
+    column_label: 'no JIT',
+    detector: ->(ruby_vm) { !jit_enabled?(ruby_vm, :YJIT) && !jit_enabled?(ruby_vm, :ZJIT) }
+  )
+
+  YJIT = new(
+    id: :yjit,
+    cli_flags: %w[--yjit].freeze,
+    label: 'YJIT',
+    column_label: 'YJIT',
+    detector: ->(ruby_vm) { jit_enabled?(ruby_vm, :YJIT) },
+    stats_reader: lambda { |ruby_vm|
+      normalize_stats(ruby_vm.const_get(:YJIT).runtime_stats,
+                      compiled: :compiled_iseq_count,
+                      failed: :compilation_failure,
+                      code_bytes: :code_region_size)
+    }
+  )
+
+  ZJIT = new(
+    id: :zjit,
+    cli_flags: %w[--zjit].freeze,
+    label: 'ZJIT',
+    column_label: 'ZJIT',
+    detector: ->(ruby_vm) { jit_enabled?(ruby_vm, :ZJIT) },
+    stats_reader: lambda { |ruby_vm|
+      normalize_stats(ruby_vm.const_get(:ZJIT).stats,
+                      compiled: :compiled_iseq_count,
+                      failed: :failed_iseq_count,
+                      code_bytes: :code_region_bytes)
+    }
+  )
+
+  ALL = [NO_JIT, YJIT, ZJIT].freeze
+
+  def self.fetch(id)
+    ALL.find { |mode| mode.id == id.to_sym } ||
+      raise(ArgumentError, "unknown Ruby mode #{id.inspect} (known: #{ALL.map(&:id).join(', ')})")
+  end
+
+  # The mode the given VM is running under. Detectors are mutually exclusive,
+  # so exactly one matches.
+  def self.active(ruby_vm = RubyVM)
+    ALL.find { |mode| mode.active?(ruby_vm) }
+  end
+
+  # The mode named by the environment, or nil if it names none.
+  def self.expected(env)
+    id = env[ENV_VAR]
+    id && fetch(id)
+  end
+
+  # Returns `actual`, or raises if it isn't what was expected.
+  #
+  # A Ruby that can't honor --yjit/--zjit only warns and falls back to the
+  # interpreter, which would otherwise be measured and published under the
+  # JIT's label.
+  #
+  # @param actual [RubyMode] what the VM reports
+  # @param expected [RubyMode, nil] what was asked for; nil skips the check
+  def self.verify!(actual:, expected:, ruby_description: RUBY_DESCRIPTION)
+    return actual if expected.nil? || expected.equal?(actual)
+
+    raise Mismatch,
+          "expected to be running under #{expected.label} (#{ENV_VAR}=#{expected.id}) but the VM " \
+          "reports #{actual.label} is active (#{ruby_description}) - was this Ruby built with " \
+          'YJIT/ZJIT support?'
+  end
+end

--- a/benchmarks/serialization_tests.rb
+++ b/benchmarks/serialization_tests.rb
@@ -4,7 +4,7 @@
 module SerializationTests
   # Determines if YJIT testing is applicable for a given implementation
   def self.yjit_applicable?(impl_type)
-    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit/, '').to_sym
+    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
     base_impl != :native
   end
 
@@ -95,7 +95,7 @@ module SerializationTests
   attr_accessor :impl_type
 
   def base_impl_type
-    impl_type.to_s.sub(/_with_yjit|_without_yjit/, '').to_sym
+    impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
   end
 
   def sanity_checks
@@ -175,7 +175,11 @@ module SerializationTests
                  end
 
     yjit_suffix = if SerializationTests.yjit_applicable?(impl_type)
-                    impl_type.to_s.include?('with_yjit') ? ' (YJIT)' : ' (no YJIT)'
+                    case impl_type.to_s
+                    when /with_yjit/ then ' (YJIT)'
+                    when /with_zjit/ then ' (ZJIT)'
+                    else ' (no YJIT)'
+                    end
                   else
                     ''
                   end

--- a/benchmarks/serialization_tests.rb
+++ b/benchmarks/serialization_tests.rb
@@ -2,12 +2,6 @@
 
 # Shared test definitions for serialization benchmarks
 module SerializationTests
-  # Determines if YJIT testing is applicable for a given implementation
-  def self.yjit_applicable?(impl_type)
-    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
-    base_impl != :native
-  end
-
   def self.metadata
     # Create a temporary instance to access fixture data
     instance = Class.new do
@@ -48,54 +42,38 @@ module SerializationTests
       'test_cases' => [
         {
           'name' => "to_s (Bootstrap - #{(instance.bootstrap_css.length / 1024.0).round}KB)",
-          'key' => 'bootstrap_compact',
+          'id' => 'bootstrap_compact',
           'bytes' => instance.bootstrap_css.length,
           'method' => 'to_s'
         },
         {
           'name' => "to_s (Compact utilities - #{(instance.compact_css.length / 1024.0).round(1)}KB)",
-          'key' => 'compact',
+          'id' => 'compact',
           'bytes' => instance.compact_css.length,
           'method' => 'to_s'
         },
         {
           'name' => "to_formatted_s (Nested CSS - #{(instance.nested_css.length / 1024.0).round(1)}KB)",
-          'key' => 'formatted_nested',
+          'id' => 'formatted_nested',
           'bytes' => instance.nested_css.length,
           'method' => 'to_formatted_s'
         },
         {
           'name' => "to_s with selector_lists (#{(instance.selector_lists_css.length / 1024.0).round(1)}KB)",
-          'key' => 'selector_lists',
+          'id' => 'selector_lists',
           'bytes' => instance.selector_lists_css.length,
           'method' => 'to_s',
           'selector_lists' => true
         },
         {
           'name' => 'Media filtering (Bootstrap print only)',
-          'key' => 'media_print',
+          'id' => 'media_print',
           'bytes' => instance.bootstrap_css.length,
           'method' => 'to_s',
           'media' => 'print'
         }
       ]
     }
-  end
-
-  def self.speedup_config
-    # Compare cataract pure without YJIT (baseline) vs cataract native (comparison)
-    {
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-      test_case_key: :key
-    }
-  end
-
-  # Must be set by including class before calling methods
-  attr_accessor :impl_type
-
-  def base_impl_type
-    impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
   end
 
   def sanity_checks
@@ -105,7 +83,7 @@ module SerializationTests
     raise "Nested CSS fixture not found at #{nested_path}" unless File.exist?(nested_path)
     raise "Selector lists CSS fixture not found at #{selector_lists_path}" unless File.exist?(selector_lists_path)
 
-    case base_impl_type
+    case implementation.backend.id
     when :pure, :native
       # Verify parsing and serialization work
       cataract_sheet = Cataract.parse_css(bootstrap_css)
@@ -166,30 +144,9 @@ module SerializationTests
     @selector_lists_path ||= File.expand_path('../test/fixtures/serialization_selector_lists.css', __dir__)
   end
 
-  def implementation_label
-    base_label = case base_impl_type
-                 when :pure
-                   'cataract pure'
-                 when :native
-                   'cataract'
-                 end
-
-    yjit_suffix = if SerializationTests.yjit_applicable?(impl_type)
-                    case impl_type.to_s
-                    when /with_yjit/ then ' (YJIT)'
-                    when /with_zjit/ then ' (ZJIT)'
-                    else ' (no YJIT)'
-                    end
-                  else
-                    ''
-                  end
-
-    "#{base_label}#{yjit_suffix}"
-  end
-
   def run_bootstrap_compact_benchmark
     puts '=' * 80
-    puts "TEST: to_s (Bootstrap) - #{implementation_label}"
+    puts "TEST: to_s (Bootstrap) - #{implementation.label}"
     puts '=' * 80
     puts '(Parsing done once before benchmark, not included in measurements)'
 
@@ -199,7 +156,7 @@ module SerializationTests
       # Pre-parse CSS once
       cataract_parsed = Cataract.parse_css(bootstrap_css)
 
-      x.report("#{base_impl_type}: bootstrap_compact") do
+      x.report(result_name('bootstrap_compact')) do
         cataract_parsed.to_s
       end
     end
@@ -207,7 +164,7 @@ module SerializationTests
 
   def run_compact_benchmark
     puts "\n#{'=' * 80}"
-    puts "TEST: to_s (Compact utilities) - #{implementation_label}"
+    puts "TEST: to_s (Compact utilities) - #{implementation.label}"
     puts '=' * 80
     puts '(Many simple rules, minimal whitespace when serialized)'
 
@@ -217,7 +174,7 @@ module SerializationTests
       # Pre-parse CSS once
       cataract_parsed = Cataract.parse_css(compact_css)
 
-      x.report("#{base_impl_type}: compact") do
+      x.report(result_name('compact')) do
         cataract_parsed.to_s
       end
     end
@@ -225,7 +182,7 @@ module SerializationTests
 
   def run_formatted_nested_benchmark
     puts "\n#{'=' * 80}"
-    puts "TEST: to_formatted_s (Nested CSS) - #{implementation_label}"
+    puts "TEST: to_formatted_s (Nested CSS) - #{implementation.label}"
     puts '=' * 80
     puts '(Nested selectors and media queries, formatted with indentation)'
 
@@ -235,7 +192,7 @@ module SerializationTests
       # Pre-parse CSS once
       cataract_parsed = Cataract.parse_css(nested_css)
 
-      x.report("#{base_impl_type}: formatted_nested") do
+      x.report(result_name('formatted_nested')) do
         cataract_parsed.to_formatted_s
       end
     end
@@ -243,7 +200,7 @@ module SerializationTests
 
   def run_selector_lists_benchmark
     puts "\n#{'=' * 80}"
-    puts "TEST: to_s with selector_lists tracking - #{implementation_label}"
+    puts "TEST: to_s with selector_lists tracking - #{implementation.label}"
     puts '=' * 80
     puts '(Many comma-separated selector lists to test tracking overhead)'
 
@@ -253,7 +210,7 @@ module SerializationTests
       # Pre-parse CSS once with selector_lists enabled
       cataract_parsed = Cataract::Stylesheet.parse(selector_lists_css, parser: { selector_lists: true })
 
-      x.report("#{base_impl_type}: selector_lists") do
+      x.report(result_name('selector_lists')) do
         cataract_parsed.to_s
       end
     end
@@ -261,7 +218,7 @@ module SerializationTests
 
   def run_media_filtering_benchmark
     puts "\n#{'=' * 80}"
-    puts "TEST: Media filtering - to_s(media: :print) - #{implementation_label}"
+    puts "TEST: Media filtering - to_s(media: :print) - #{implementation.label}"
     puts '=' * 80
     puts '(Bootstrap CSS filtered to print media only)'
 
@@ -272,7 +229,7 @@ module SerializationTests
       cataract_parser = Cataract::Stylesheet.new
       cataract_parser.add_block(bootstrap_css)
 
-      x.report("#{base_impl_type}: media_print") do
+      x.report(result_name('media_print')) do
         cataract_parser.to_s(media: :print)
       end
     end

--- a/benchmarks/specificity_tests.rb
+++ b/benchmarks/specificity_tests.rb
@@ -4,7 +4,7 @@
 module SpecificityTests
   # Determines if YJIT testing is applicable for a given implementation
   def self.yjit_applicable?(impl_type)
-    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit/, '').to_sym
+    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
     base_impl != :native
   end
 
@@ -63,7 +63,7 @@ module SpecificityTests
   attr_accessor :impl_type
 
   def base_impl_type
-    impl_type.to_s.sub(/_with_yjit|_without_yjit/, '').to_sym
+    impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
   end
 
   def sanity_checks
@@ -101,7 +101,11 @@ module SpecificityTests
                  end
 
     yjit_suffix = if SpecificityTests.yjit_applicable?(impl_type)
-                    impl_type.to_s.include?('with_yjit') ? ' (YJIT)' : ' (no YJIT)'
+                    case impl_type.to_s
+                    when /with_yjit/ then ' (YJIT)'
+                    when /with_zjit/ then ' (ZJIT)'
+                    else ' (no YJIT)'
+                    end
                   else
                     ''
                   end

--- a/benchmarks/specificity_tests.rb
+++ b/benchmarks/specificity_tests.rb
@@ -2,43 +2,37 @@
 
 # Shared test definitions for specificity benchmarks
 module SpecificityTests
-  # Determines if YJIT testing is applicable for a given implementation
-  def self.yjit_applicable?(impl_type)
-    base_impl = impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
-    base_impl != :native
-  end
-
   def self.metadata
     {
       'test_cases' => [
         {
           'name' => 'Simple Selectors',
-          'key' => 'simple',
+          'id' => 'simple',
           'selectors' => { 'div' => 1, '.class' => 10, '#id' => 100 }
         },
         {
           'name' => 'Compound Selectors',
-          'key' => 'compound',
+          'id' => 'compound',
           'selectors' => { 'div.container' => 11, 'div#main' => 101, 'div.container#main' => 111 }
         },
         {
           'name' => 'Combinators',
-          'key' => 'combinators',
+          'id' => 'combinators',
           'selectors' => { 'div p' => 2, 'div > p' => 2, 'h1 + p' => 2, 'div.container > p.intro' => 22 }
         },
         {
           'name' => 'Pseudo-classes & Pseudo-elements',
-          'key' => 'pseudo',
+          'id' => 'pseudo',
           'selectors' => { 'a:hover' => 11, 'p::before' => 2, 'li:first-child' => 11, 'p:first-child::before' => 12 }
         },
         {
           'name' => ':not() Pseudo-class (CSS3)',
-          'key' => 'not',
+          'id' => 'not',
           'selectors' => { '#s12:not(foo)' => 101, 'div:not(.active)' => 11, '.button:not([disabled])' => 20 }
         },
         {
           'name' => 'Complex Real-world Selectors',
-          'key' => 'complex',
+          'id' => 'complex',
           'selectors' => {
             'ul#nav li.active a:hover' => 122,
             'div.wrapper > article#main > section.content > p:first-child' => 123,
@@ -49,25 +43,8 @@ module SpecificityTests
     }
   end
 
-  def self.speedup_config
-    # Compare cataract pure without YJIT (baseline) vs cataract native (comparison)
-    # For fair comparison, compare both without YJIT optimizations
-    {
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-      test_case_key: :key
-    }
-  end
-
-  # Must be set by including class before calling methods
-  attr_accessor :impl_type
-
-  def base_impl_type
-    impl_type.to_s.sub(/_with_yjit|_without_yjit|_with_zjit/, '').to_sym
-  end
-
   def sanity_checks
-    case base_impl_type
+    case implementation.backend.id
     when :pure, :native
       # Verify Cataract calculations
       raise 'Cataract simple selector failed' unless specificity_of('div') == 1
@@ -92,34 +69,13 @@ module SpecificityTests
 
   private
 
-  def implementation_label
-    base_label = case base_impl_type
-                 when :pure
-                   'cataract pure'
-                 when :native
-                   'cataract'
-                 end
-
-    yjit_suffix = if SpecificityTests.yjit_applicable?(impl_type)
-                    case impl_type.to_s
-                    when /with_yjit/ then ' (YJIT)'
-                    when /with_zjit/ then ' (ZJIT)'
-                    else ' (no YJIT)'
-                    end
-                  else
-                    ''
-                  end
-
-    "#{base_label}#{yjit_suffix}"
-  end
-
   def benchmark_category(test_case)
     puts '=' * 80
-    puts "TEST: #{test_case['name']} - #{implementation_label}"
+    puts "TEST: #{test_case['name']} - #{implementation.label}"
     puts test_case['note'] if test_case['note']
     puts '=' * 80
 
-    key = test_case['key']
+    id = test_case['id']
     selectors = test_case['selectors']
 
     # Show individual selector examples in terminal output
@@ -129,23 +85,13 @@ module SpecificityTests
     end
     puts
 
-    benchmark(key) do |x|
+    # Both backends run identical code; which one is exercised was decided
+    # when `require 'cataract'` picked a backend.
+    benchmark(id) do |x|
       x.config(time: 2, warmup: 1)
 
-      case base_impl_type
-      when :pure
-        x.report("cataract pure: #{key}") do
-          selectors.each_key do |selector|
-            specificity_of(selector)
-          end
-        end
-
-      when :native
-        x.report("cataract: #{key}") do
-          selectors.each_key do |selector|
-            specificity_of(selector)
-          end
-        end
+      x.report(result_name(id)) do
+        selectors.each_key { |selector| specificity_of(selector) }
       end
     end
   end

--- a/benchmarks/speedup_calculator.rb
+++ b/benchmarks/speedup_calculator.rb
@@ -81,6 +81,10 @@ class SpeedupCalculator
       ->(result) { result['implementation'] == 'pure_with_yjit' }
     end
 
+    def self.cataract_pure_with_zjit
+      ->(result) { result['implementation'] == 'pure_with_zjit' }
+    end
+
     def self.cataract_native
       ->(result) { base_implementation(result) == 'native' }
     end
@@ -91,6 +95,10 @@ class SpeedupCalculator
 
     def self.without_yjit
       ->(result) { result['implementation']&.include?('without_yjit') }
+    end
+
+    def self.with_zjit
+      ->(result) { result['implementation']&.include?('with_zjit') }
     end
 
     def self.pure_ruby
@@ -105,7 +113,7 @@ class SpeedupCalculator
 
     # Extract base implementation from impl_type (strips YJIT suffixes)
     def self.base_implementation(result)
-      result['implementation']&.to_s&.sub(/_with_yjit|_without_yjit/, '')
+      result['implementation']&.to_s&.sub(/_with_yjit|_without_yjit|_with_zjit/, '')
     end
   end
 end

--- a/benchmarks/speedup_calculator.rb
+++ b/benchmarks/speedup_calculator.rb
@@ -1,47 +1,38 @@
 # frozen_string_literal: true
 
-# Generic speedup calculator for benchmark results
-# Compares "baseline" vs "comparison" results and calculates speedup stats
+require_relative 'implementation'
+
+# Compares two implementations across every test case they share and reports
+# the spread of speedups.
 #
-# CONVENTION: Result names must use format "tool_name: test_case_id"
-# Example: "pure_without_yjit: CSS1", "native: CSS1"
+# CONVENTION: benchmark-ips report names must be "label: test_case_id", where
+# test_case_id exactly matches the 'id' of an entry in the benchmark's
+# metadata. Example: "cataract pure: selector lists".
 class SpeedupCalculator
-  # @param results [Array<Hash>] Array of benchmark results with 'name' and 'central_tendency'
-  # @param test_cases [Array<Hash>] Array of test case metadata to annotate with speedups
-  # @param baseline_matcher [Proc] Block that returns true if result is baseline (e.g., pure Ruby)
-  # @param comparison_matcher [Proc] Block that returns true if result is comparison (e.g., native C)
-  # @param test_case_key [Symbol] Key in test_cases hash to match against test case id from result name
-  def initialize(results:, test_cases:, baseline_matcher:, comparison_matcher:, test_case_key: nil)
+  # @param results [Array<Hash>] benchmark result rows
+  # @param test_cases [Array<Hash>] test case metadata, annotated in place with per-case speedups
+  # @param baseline [Implementation] the implementation being compared against
+  # @param comparison [Implementation] the implementation whose speedup is reported
+  def initialize(results:, test_cases:, baseline:, comparison:)
     @results = results
     @test_cases = test_cases
-    @baseline_matcher = baseline_matcher
-    @comparison_matcher = comparison_matcher
-    @test_case_key = test_case_key
+    @baseline = baseline
+    @comparison = comparison
   end
 
-  # Calculate speedups and return stats hash
-  # Also annotates test_cases with individual speedups if test_case_key provided
-  # @return [Hash] { min: Float, max: Float, avg: Float } or nil if no pairs found
+  # @return [Hash, nil] { 'min' => Float, 'max' => Float, 'avg' => Float }, or
+  #   nil when the two implementations share no test case
   def calculate
     speedups = []
 
-    # Group results by test case (everything after ':')
-    grouped = @results.group_by { |result| extract_test_case(result['name']) }
-
-    grouped.each do |test_case_id, group_results|
-      baseline = group_results.find(&@baseline_matcher)
-      comparison = group_results.find(&@comparison_matcher)
-
+    @results.group_by { |result| test_case_id(result) }.each do |id, group|
+      baseline = group.find { |result| @baseline.produced?(result) }
+      comparison = group.find { |result| @comparison.produced?(result) }
       next unless baseline && comparison
 
       speedup = comparison['central_tendency'].to_f / baseline['central_tendency']
       speedups << speedup
-
-      # Annotate test case metadata if provided
-      if @test_case_key && @test_cases
-        test_case = @test_cases.find { |tc| tc[@test_case_key.to_s] == test_case_id }
-        test_case['speedup'] = speedup.round(2) if test_case
-      end
+      annotate(id, speedup)
     end
 
     return nil if speedups.empty?
@@ -55,65 +46,15 @@ class SpeedupCalculator
 
   private
 
-  # Extract test case id from result name
-  # "pure_without_yjit: CSS1" -> "CSS1"
-  # "native: all" -> "all"
-  def extract_test_case(name)
-    name.split(':').last.strip
+  # "cataract pure: selector lists" -> "selector lists"
+  def test_case_id(result)
+    result['name'].split(':').last.strip
   end
 
-  # Common matchers
-  class Matchers
-    def self.cataract
-      # Matches native cataract (for backwards compatibility)
-      ->(result) { base_implementation(result) == 'native' }
-    end
+  def annotate(id, speedup)
+    return unless @test_cases
 
-    def self.cataract_pure
-      ->(result) { base_implementation(result) == 'pure' }
-    end
-
-    def self.cataract_pure_without_yjit
-      ->(result) { result['implementation'] == 'pure_without_yjit' }
-    end
-
-    def self.cataract_pure_with_yjit
-      ->(result) { result['implementation'] == 'pure_with_yjit' }
-    end
-
-    def self.cataract_pure_with_zjit
-      ->(result) { result['implementation'] == 'pure_with_zjit' }
-    end
-
-    def self.cataract_native
-      ->(result) { base_implementation(result) == 'native' }
-    end
-
-    def self.with_yjit
-      ->(result) { result['implementation']&.include?('with_yjit') }
-    end
-
-    def self.without_yjit
-      ->(result) { result['implementation']&.include?('without_yjit') }
-    end
-
-    def self.with_zjit
-      ->(result) { result['implementation']&.include?('with_zjit') }
-    end
-
-    def self.pure_ruby
-      ->(result) { base_implementation(result) == 'pure' }
-    end
-
-    def self.native_extension
-      ->(result) { base_implementation(result) == 'native' }
-    end
-
-    private
-
-    # Extract base implementation from impl_type (strips YJIT suffixes)
-    def self.base_implementation(result)
-      result['implementation']&.to_s&.sub(/_with_yjit|_without_yjit|_with_zjit/, '')
-    end
+    test_case = @test_cases.find { |tc| tc['id'] == id }
+    test_case['speedup'] = speedup.round(2) if test_case
   end
 end

--- a/benchmarks/system_metadata.rb
+++ b/benchmarks/system_metadata.rb
@@ -2,12 +2,12 @@
 
 require 'json'
 require 'fileutils'
+require_relative 'results_directory'
 
 # Collects system metadata for benchmark runs
 class SystemMetadata
-  RESULTS_DIR = File.expand_path('.results', __dir__)
-
-  def self.collect
+  # @param results [ResultsDirectory] where metadata.json is written
+  def self.collect(results = ResultsDirectory.from_env(ENV))
     metadata = {
       'ruby_version' => RUBY_VERSION,
       'ruby_description' => RUBY_DESCRIPTION,
@@ -18,8 +18,7 @@ class SystemMetadata
       'timestamp' => Time.now.iso8601
     }
 
-    FileUtils.mkdir_p(RESULTS_DIR)
-    File.write(File.join(RESULTS_DIR, 'metadata.json'), JSON.pretty_generate(metadata))
+    results.create.write('metadata.json', metadata)
 
     metadata
   end

--- a/benchmarks/templates/benchmarks.md.erb
+++ b/benchmarks/templates/benchmarks.md.erb
@@ -19,118 +19,23 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 
 <%= parsing_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|-----------|--------|----------------|-------------|-------------|
-<%- parsing_data['metadata']['test_cases'].each do |test_case| -%>
-<%- results = parsing_data['results'].select { |r| r['name'].include?(test_case['fixture']) } -%>
-<%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
-<%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
-<%- pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' } -%>
-<%- native = results.find { |r| r['implementation'] == 'native' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
-<%- end -%>
+<%= result_table(parsing_data) %>
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-<%= speedup_rows(parsing_data, test_case_key: :fixture) %>
+<%= speedup_rows(parsing_data) %>
 
 ### Parse Error Checking Overhead
 
 Parse error detection can be enabled with `raise_parse_errors: true`. This compares performance impact:
 
-| Configuration | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|---------------|--------|----------------|-------------|-------------|
-<%- if parsing_data['metadata']['error_checking'] -%>
-<%- parsing_data['metadata']['error_checking'].each do |test_case| -%>
-<%-
-  # Match results by checking if the name contains the key words
-  search_term = test_case['key'].gsub('_', ' ')
-  results = parsing_data['results'].select { |r| r['name'].include?(search_term) }
-  pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' }
-  pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' }
-  pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' }
-  native = results.find { |r| r['implementation'] == 'native' }
--%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
-<%- end -%>
+<%= result_table(parsing_data, test_cases: parsing_data['metadata']['error_checking'], row_header: 'Configuration') %>
 
 **Overhead Analysis:**
 
-<%-
-  # Calculate overhead for each implementation
-  off_results = parsing_data['results'].select { |r| r['name'].include?('error checking off') }
-  on_results = parsing_data['results'].select { |r| r['name'].include?('error checking on') }
-
-  native_off = off_results.find { |r| r['implementation'] == 'native' }
-  native_on = on_results.find { |r| r['implementation'] == 'native' }
-
-  pure_no_yjit_off = off_results.find { |r| r['implementation'] == 'pure_without_yjit' }
-  pure_no_yjit_on = on_results.find { |r| r['implementation'] == 'pure_without_yjit' }
-
-  pure_with_yjit_off = off_results.find { |r| r['implementation'] == 'pure_with_yjit' }
-  pure_with_yjit_on = on_results.find { |r| r['implementation'] == 'pure_with_yjit' }
-
-  pure_with_zjit_off = off_results.find { |r| r['implementation'] == 'pure_with_zjit' }
-  pure_with_zjit_on = on_results.find { |r| r['implementation'] == 'pure_with_zjit' }
--%>
-
-| Implementation | Overhead |
-|----------------|----------|
-<%- if native_off && native_on -%>
-<%-
-  slowdown = ((native_off['ips'] / native_on['ips']) - 1) * 100
-  overhead_text = if slowdown.abs < 1.0
-    "~0% (within noise)"
-  elsif slowdown < 0
-    "%.1f%% faster (unexpected)" % slowdown.abs
-  else
-    "%.1f%% slower" % slowdown
-  end
--%>
-| Native | <%= overhead_text %> |
-<%- end -%>
-<%- if pure_no_yjit_off && pure_no_yjit_on -%>
-<%-
-  slowdown = ((pure_no_yjit_off['ips'] / pure_no_yjit_on['ips']) - 1) * 100
-  overhead_text = if slowdown.abs < 1.0
-    "~0% (within noise)"
-  elsif slowdown < 0
-    "%.1f%% faster (unexpected)" % slowdown.abs
-  else
-    "%.1f%% slower" % slowdown
-  end
--%>
-| Pure (no YJIT) | <%= overhead_text %> |
-<%- end -%>
-<%- if pure_with_yjit_off && pure_with_yjit_on -%>
-<%-
-  slowdown = ((pure_with_yjit_off['ips'] / pure_with_yjit_on['ips']) - 1) * 100
-  overhead_text = if slowdown.abs < 1.0
-    "~0% (within noise)"
-  elsif slowdown < 0
-    "%.1f%% faster (unexpected)" % slowdown.abs
-  else
-    "%.1f%% slower" % slowdown
-  end
--%>
-| Pure (YJIT) | <%= overhead_text %> |
-<%- end -%>
-<%- if pure_with_zjit_off && pure_with_zjit_on -%>
-<%-
-  slowdown = ((pure_with_zjit_off['ips'] / pure_with_zjit_on['ips']) - 1) * 100
-  overhead_text = if slowdown.abs < 1.0
-    "~0% (within noise)"
-  elsif slowdown < 0
-    "%.1f%% faster (unexpected)" % slowdown.abs
-  else
-    "%.1f%% slower" % slowdown
-  end
--%>
-| Pure (ZJIT) | <%= overhead_text %> |
-<%- end -%>
-<%- end -%>
+<%= overhead_table(parsing_data, without_id: 'error checking off', with_id: 'error checking on') %>
 
 ---
 <%- end -%>
@@ -140,22 +45,13 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
 <%= serialization_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|-----------|--------|----------------|-------------|-------------|
-<%- serialization_data['metadata']['test_cases'].each do |test_case| -%>
-<%- results = serialization_data['results'].select { |r| r['name'].include?(test_case['key']) } -%>
-<%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
-<%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
-<%- pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' } -%>
-<%- native = results.find { |r| r['implementation'] == 'native' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
-<%- end -%>
+<%= result_table(serialization_data) %>
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-<%= speedup_rows(serialization_data, test_case_key: :key) %>
+<%= speedup_rows(serialization_data) %>
 
 ---
 <%- end -%>
@@ -165,22 +61,13 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
 <%= specificity_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|-----------|--------|----------------|-------------|-------------|
-<%- specificity_data['metadata']['test_cases'].each do |test_case| -%>
-<%- results = specificity_data['results'].select { |r| r['name'].include?(test_case['key']) } -%>
-<%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
-<%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
-<%- pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' } -%>
-<%- native = results.find { |r| r['implementation'] == 'native' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
-<%- end -%>
+<%= result_table(specificity_data) %>
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-<%= speedup_rows(specificity_data, test_case_key: :key) %>
+<%= speedup_rows(specificity_data) %>
 
 ---
 <%- end -%>
@@ -190,22 +77,13 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
 <%= flattening_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
-|-----------|--------|----------------|-------------|-------------|
-<%- flattening_data['metadata']['test_cases'].each do |test_case| -%>
-<%- results = flattening_data['results'].select { |r| r['name'].include?(test_case['key']) } -%>
-<%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
-<%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
-<%- pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' } -%>
-<%- native = results.find { |r| r['implementation'] == 'native' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
-<%- end -%>
+<%= result_table(flattening_data) %>
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-<%= speedup_rows(flattening_data, test_case_key: :key) %>
+<%= speedup_rows(flattening_data) %>
 
 ---
 <%- end -%>
@@ -230,5 +108,6 @@ rake benchmark:generate_docs
 
 - Benchmarks use benchmark-ips with 1-2s warmup and 2-5s measurement periods
 - Measurements show median iterations per second (i/s)
-- YJIT/ZJIT are enabled per subprocess (one JIT per process - Ruby only allows one to be active at a time) for accurate comparison
+- Each backend/JIT combination is measured in its own subprocess - Ruby allows only one JIT active per process, and each subprocess verifies the JIT it was launched with is the one actually running before measuring anything
+- The C extension is measured without a JIT: its speed doesn't depend on a JIT compiling Cataract's own code
 - ZJIT is an experimental, method-based JIT introduced in Ruby 4.0. It is not enabled by default and is not yet expected to outperform YJIT; it's included here to track its progress release over release

--- a/benchmarks/templates/benchmarks.md.erb
+++ b/benchmarks/templates/benchmarks.md.erb
@@ -4,7 +4,7 @@
 
 # Performance Benchmarks
 
-Performance comparison between Cataract's C extension and pure Ruby implementations.
+Performance comparison between Cataract's C extension and pure Ruby implementations, including pure Ruby under the interpreter, YJIT, and ZJIT.
 
 ## Test Environment
 
@@ -19,14 +19,15 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 
 <%= parsing_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
-|-----------|--------|----------------|-------------|
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|-----------|--------|----------------|-------------|-------------|
 <%- parsing_data['metadata']['test_cases'].each do |test_case| -%>
 <%- results = parsing_data['results'].select { |r| r['name'].include?(test_case['fixture']) } -%>
 <%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
 <%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
+<%- pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' } -%>
 <%- native = results.find { |r| r['implementation'] == 'native' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> |
+| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
 <%- end -%>
 
 ### Speedups
@@ -39,8 +40,8 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 
 Parse error detection can be enabled with `raise_parse_errors: true`. This compares performance impact:
 
-| Configuration | Native | Pure (no YJIT) | Pure (YJIT) |
-|---------------|--------|----------------|-------------|
+| Configuration | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|---------------|--------|----------------|-------------|-------------|
 <%- if parsing_data['metadata']['error_checking'] -%>
 <%- parsing_data['metadata']['error_checking'].each do |test_case| -%>
 <%-
@@ -49,9 +50,10 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
   results = parsing_data['results'].select { |r| r['name'].include?(search_term) }
   pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' }
   pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' }
+  pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' }
   native = results.find { |r| r['implementation'] == 'native' }
 -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> |
+| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
 <%- end -%>
 
 **Overhead Analysis:**
@@ -69,6 +71,9 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
   pure_with_yjit_off = off_results.find { |r| r['implementation'] == 'pure_with_yjit' }
   pure_with_yjit_on = on_results.find { |r| r['implementation'] == 'pure_with_yjit' }
+
+  pure_with_zjit_off = off_results.find { |r| r['implementation'] == 'pure_with_zjit' }
+  pure_with_zjit_on = on_results.find { |r| r['implementation'] == 'pure_with_zjit' }
 -%>
 
 | Implementation | Overhead |
@@ -112,6 +117,19 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 -%>
 | Pure (YJIT) | <%= overhead_text %> |
 <%- end -%>
+<%- if pure_with_zjit_off && pure_with_zjit_on -%>
+<%-
+  slowdown = ((pure_with_zjit_off['ips'] / pure_with_zjit_on['ips']) - 1) * 100
+  overhead_text = if slowdown.abs < 1.0
+    "~0% (within noise)"
+  elsif slowdown < 0
+    "%.1f%% faster (unexpected)" % slowdown.abs
+  else
+    "%.1f%% slower" % slowdown
+  end
+-%>
+| Pure (ZJIT) | <%= overhead_text %> |
+<%- end -%>
 <%- end -%>
 
 ---
@@ -122,14 +140,15 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
 <%= serialization_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
-|-----------|--------|----------------|-------------|
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|-----------|--------|----------------|-------------|-------------|
 <%- serialization_data['metadata']['test_cases'].each do |test_case| -%>
 <%- results = serialization_data['results'].select { |r| r['name'].include?(test_case['key']) } -%>
 <%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
 <%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
+<%- pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' } -%>
 <%- native = results.find { |r| r['implementation'] == 'native' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> |
+| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
 <%- end -%>
 
 ### Speedups
@@ -146,14 +165,15 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
 <%= specificity_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
-|-----------|--------|----------------|-------------|
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|-----------|--------|----------------|-------------|-------------|
 <%- specificity_data['metadata']['test_cases'].each do |test_case| -%>
 <%- results = specificity_data['results'].select { |r| r['name'].include?(test_case['key']) } -%>
 <%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
 <%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
+<%- pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' } -%>
 <%- native = results.find { |r| r['implementation'] == 'native' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> |
+| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
 <%- end -%>
 
 ### Speedups
@@ -170,14 +190,15 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
 <%= flattening_data['description'] %>
 
-| Test Case | Native | Pure (no YJIT) | Pure (YJIT) |
-|-----------|--------|----------------|-------------|
+| Test Case | Native | Pure (no YJIT) | Pure (YJIT) | Pure (ZJIT) |
+|-----------|--------|----------------|-------------|-------------|
 <%- flattening_data['metadata']['test_cases'].each do |test_case| -%>
 <%- results = flattening_data['results'].select { |r| r['name'].include?(test_case['key']) } -%>
 <%- pure_no_yjit = results.find { |r| r['implementation'] == 'pure_without_yjit' } -%>
 <%- pure_with_yjit = results.find { |r| r['implementation'] == 'pure_with_yjit' } -%>
+<%- pure_with_zjit = results.find { |r| r['implementation'] == 'pure_with_zjit' } -%>
 <%- native = results.find { |r| r['implementation'] == 'native' } -%>
-| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> |
+| <%= test_case['name'] %> | <%= native ? format_ips(native, short: true) : 'N/A' %> | <%= pure_no_yjit ? format_ips(pure_no_yjit, short: true) : 'N/A' %> | <%= pure_with_yjit ? format_ips(pure_with_yjit, short: true) : 'N/A' %> | <%= pure_with_zjit ? format_ips(pure_with_zjit, short: true) : 'N/A' %> |
 <%- end -%>
 
 ### Speedups
@@ -209,4 +230,5 @@ rake benchmark:generate_docs
 
 - Benchmarks use benchmark-ips with 1-2s warmup and 2-5s measurement periods
 - Measurements show median iterations per second (i/s)
-- YJIT is enabled/disabled per subprocess for accurate comparison
+- YJIT/ZJIT are enabled per subprocess (one JIT per process - Ruby only allows one to be active at a time) for accurate comparison
+- ZJIT is an experimental, method-based JIT introduced in Ruby 4.0. It is not enabled by default and is not yet expected to outperform YJIT; it's included here to track its progress release over release

--- a/benchmarks/worker_helpers.rb
+++ b/benchmarks/worker_helpers.rb
@@ -1,77 +1,30 @@
 # frozen_string_literal: true
 
-# Shared helper module for benchmark workers
+require_relative 'implementation'
+
+# Mixed into the worker benchmark classes that run inside a subprocess.
 #
-# Provides common helpers for workers including:
-# - JIT-aware impl_type determination (interpreter/YJIT/ZJIT)
-# - A pre-flight check that the JIT actually active matches what the parent
-#   process asked for, so a subprocess that silently failed to honor
-#   --yjit/--zjit doesn't get measured and mislabeled as something else
-# - Unique benchmark filenames to avoid overwriting results
+# The worker reads its backend and JIT off the running VM and verifies them
+# against what the parent asked for, so measurements can only be labeled with
+# the configuration that produced them.
 module WorkerHelpers
-  # Override benchmark_name to include impl_type suffix
-  # This prevents different JIT variants from overwriting each other's results
+  # This process's configuration. Verified on first use, before any
+  # measurement is taken.
+  def implementation
+    @implementation ||= Implementation.current
+  end
+
+  # Gives each variant its own result file so the JIT runs of one benchmark
+  # don't overwrite each other.
   def benchmark_name
-    "#{self.class.benchmark_name}_#{impl_type}"
+    "#{self.class.benchmark_name}_#{implementation.id}"
   end
 
-  private
-
-  # Determines implementation type with a JIT suffix, verifying first that
-  # the JIT actually active in this process is the one that was asked for.
-  #
-  # @param base_impl [Symbol] Base implementation (:pure, :native)
-  # @param test_module [Module] Test module that provides yjit_applicable? method
-  # @return [Symbol] Implementation type with JIT suffix if applicable
-  #
-  # Examples:
-  #   determine_impl_type(:pure, ParsingTests)
-  #   # => :pure_with_yjit (if YJIT enabled)
-  #   # => :pure_with_zjit (if ZJIT enabled)
-  #   # => :pure_without_yjit (if no JIT enabled)
-  #
-  #   determine_impl_type(:native, ParsingTests)
-  #   # => :native (JIT variants not applicable to C extensions)
-  def determine_impl_type(base_impl, test_module)
-    return base_impl unless test_module.yjit_applicable?(base_impl)
-
-    actual_jit = current_jit_mode
-    verify_jit_mode!(actual_jit)
-
-    case actual_jit
-    when :zjit then :"#{base_impl}_with_zjit"
-    when :yjit then :"#{base_impl}_with_yjit"
-    else :"#{base_impl}_without_yjit"
-    end
-  end
-
-  # Which JIT (if any) is actually active in this process right now. YJIT
-  # and ZJIT are mutually exclusive in a single Ruby process, so at most one
-  # of these is true.
-  def current_jit_mode
-    if defined?(RubyVM::ZJIT) && RubyVM::ZJIT.enabled?
-      :zjit
-    elsif defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
-      :yjit
-    else
-      :none
-    end
-  end
-
-  # Confirms the JIT actually active matches CATARACT_BENCH_JIT, the mode the
-  # parent process's subprocess launch (--disable-yjit/--yjit/--zjit)
-  # intended. Without this, a Ruby built without YJIT/ZJIT support (or an
-  # inherited RUBY_YJIT_ENABLE/RUBY_ZJIT_ENABLE env var overriding the flag)
-  # would just warn and silently fall back to the interpreter - the run
-  # would "succeed" but measure the wrong thing under the wrong label. Only
-  # checks when CATARACT_BENCH_JIT is set, so running a worker standalone
-  # for debugging (no env var) is unaffected.
-  def verify_jit_mode!(actual_jit)
-    expected_jit = ENV.fetch('CATARACT_BENCH_JIT', nil)
-    return unless expected_jit
-    return if expected_jit == actual_jit.to_s
-
-    raise "JIT mode mismatch: expected CATARACT_BENCH_JIT=#{expected_jit} but RubyVM reports " \
-          "#{actual_jit} is active (#{RUBY_DESCRIPTION}) - was this Ruby built with YJIT/ZJIT support?"
+  # Names a benchmark-ips report "label: test_case_id". The id must match the
+  # benchmark metadata exactly - that is how a measurement finds its row in
+  # BENCHMARKS.md. The label names only the backend; the JIT is recorded in
+  # the row's own fields.
+  def result_name(test_case_id)
+    "#{implementation.backend.label}: #{test_case_id}"
   end
 end

--- a/benchmarks/worker_helpers.rb
+++ b/benchmarks/worker_helpers.rb
@@ -3,34 +3,75 @@
 # Shared helper module for benchmark workers
 #
 # Provides common helpers for workers including:
-# - YJIT-aware impl_type determination
+# - JIT-aware impl_type determination (interpreter/YJIT/ZJIT)
+# - A pre-flight check that the JIT actually active matches what the parent
+#   process asked for, so a subprocess that silently failed to honor
+#   --yjit/--zjit doesn't get measured and mislabeled as something else
 # - Unique benchmark filenames to avoid overwriting results
 module WorkerHelpers
   # Override benchmark_name to include impl_type suffix
-  # This prevents different YJIT variants from overwriting each other's results
+  # This prevents different JIT variants from overwriting each other's results
   def benchmark_name
     "#{self.class.benchmark_name}_#{impl_type}"
   end
 
   private
 
-  # Determines implementation type with YJIT suffix based on actual YJIT status
+  # Determines implementation type with a JIT suffix, verifying first that
+  # the JIT actually active in this process is the one that was asked for.
   #
   # @param base_impl [Symbol] Base implementation (:pure, :native)
   # @param test_module [Module] Test module that provides yjit_applicable? method
-  # @return [Symbol] Implementation type with YJIT suffix if applicable
+  # @return [Symbol] Implementation type with JIT suffix if applicable
   #
   # Examples:
-  #   determine_impl_type_with_yjit(:pure, ParsingTests)
+  #   determine_impl_type(:pure, ParsingTests)
   #   # => :pure_with_yjit (if YJIT enabled)
-  #   # => :pure_without_yjit (if YJIT disabled)
+  #   # => :pure_with_zjit (if ZJIT enabled)
+  #   # => :pure_without_yjit (if no JIT enabled)
   #
-  #   determine_impl_type_with_yjit(:native, ParsingTests)
-  #   # => :native (YJIT not applicable to C extensions)
-  def determine_impl_type_with_yjit(base_impl, test_module)
+  #   determine_impl_type(:native, ParsingTests)
+  #   # => :native (JIT variants not applicable to C extensions)
+  def determine_impl_type(base_impl, test_module)
     return base_impl unless test_module.yjit_applicable?(base_impl)
 
-    yjit_enabled = defined?(RubyVM::YJIT.enabled?) && RubyVM::YJIT.enabled?
-    yjit_enabled ? :"#{base_impl}_with_yjit" : :"#{base_impl}_without_yjit"
+    actual_jit = current_jit_mode
+    verify_jit_mode!(actual_jit)
+
+    case actual_jit
+    when :zjit then :"#{base_impl}_with_zjit"
+    when :yjit then :"#{base_impl}_with_yjit"
+    else :"#{base_impl}_without_yjit"
+    end
+  end
+
+  # Which JIT (if any) is actually active in this process right now. YJIT
+  # and ZJIT are mutually exclusive in a single Ruby process, so at most one
+  # of these is true.
+  def current_jit_mode
+    if defined?(RubyVM::ZJIT) && RubyVM::ZJIT.enabled?
+      :zjit
+    elsif defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+      :yjit
+    else
+      :none
+    end
+  end
+
+  # Confirms the JIT actually active matches CATARACT_BENCH_JIT, the mode the
+  # parent process's subprocess launch (--disable-yjit/--yjit/--zjit)
+  # intended. Without this, a Ruby built without YJIT/ZJIT support (or an
+  # inherited RUBY_YJIT_ENABLE/RUBY_ZJIT_ENABLE env var overriding the flag)
+  # would just warn and silently fall back to the interpreter - the run
+  # would "succeed" but measure the wrong thing under the wrong label. Only
+  # checks when CATARACT_BENCH_JIT is set, so running a worker standalone
+  # for debugging (no env var) is unaffected.
+  def verify_jit_mode!(actual_jit)
+    expected_jit = ENV.fetch('CATARACT_BENCH_JIT', nil)
+    return unless expected_jit
+    return if expected_jit == actual_jit.to_s
+
+    raise "JIT mode mismatch: expected CATARACT_BENCH_JIT=#{expected_jit} but RubyVM reports " \
+          "#{actual_jit} is active (#{RUBY_DESCRIPTION}) - was this Ruby built with YJIT/ZJIT support?"
   end
 end

--- a/scripts/generate_benchmarks_md.rb
+++ b/scripts/generate_benchmarks_md.rb
@@ -4,13 +4,25 @@
 require 'json'
 require 'erb'
 require 'fileutils'
+require_relative '../benchmarks/benchmark_formatting'
+require_relative '../benchmarks/implementation'
+require_relative '../benchmarks/result_table'
 require_relative '../benchmarks/speedup_calculator'
 
-# Generate BENCHMARKS.md from benchmark JSON results
+# Generate BENCHMARKS.md from benchmark JSON results.
+#
+# The template describes layout; the objects describe meaning. Column
+# headings, which implementations exist, and which comparisons are worth
+# reporting all come from Implementation, so the doc can only ever claim what
+# was actually measured.
 class BenchmarkDocGenerator
+  include BenchmarkFormatting
+
   RESULTS_DIR = File.expand_path('../benchmarks/.results', __dir__)
   TEMPLATE_PATH = File.expand_path('../benchmarks/templates/benchmarks.md.erb', __dir__)
   OUTPUT_PATH = File.expand_path('../BENCHMARKS.md', __dir__)
+
+  BENCHMARKS = %w[parsing serialization specificity flattening].freeze
 
   def initialize(results_dir: RESULTS_DIR, output_path: OUTPUT_PATH, verbose: true)
     @results_dir = results_dir
@@ -24,61 +36,55 @@ class BenchmarkDocGenerator
   end
 
   def generate
-    # Check if we have any data to generate
-    if !@parsing_data && !@serialization_data &&
-       !@specificity_data && !@flattening_data
+    if all_data.compact.empty?
       # :nocov:
-      if @verbose
-        puts 'Warning: No benchmark data found. Run benchmarks first: rake benchmark'
-        puts 'Available data files:'
-        Dir.glob(File.join(@results_dir, '*.json')).each do |file|
-          puts "  - #{File.basename(file)}"
-        end
-      end
+      report_no_data if @verbose
       # :nocov:
       return
     end
 
     template = ERB.new(File.read(TEMPLATE_PATH), trim_mode: '-')
-    output = template.result(binding)
+    File.write(@output_path, template.result(binding))
 
-    File.write(@output_path, output)
+    report_coverage if @verbose
+  end
 
-    return unless @verbose
+  # Comparisons reported under each benchmark's "Speedups" heading, in order.
+  # Each entry is [label, baseline, comparison]; the figure shown is
+  # comparison / baseline, so a ratio below 1 reads as "slower".
+  def self.speedup_comparisons
+    native = Implementation.find(:native, :none)
+    interpreted = Implementation.find(:pure, :none)
+    yjit = Implementation.find(:pure, :yjit)
+    zjit = Implementation.find(:pure, :zjit)
 
-    # :nocov:
-    puts 'Generated BENCHMARKS.md'
-    puts '  Included benchmarks:'
-    puts '    - Parsing' if @parsing_data
-    puts '    - Serialization' if @serialization_data
-    puts '    - Specificity' if @specificity_data
-    puts '    - Merging' if @flattening_data
-
-    missing = []
-    missing << 'Parsing' unless @parsing_data
-    missing << 'Serialization' unless @serialization_data
-    missing << 'Specificity' unless @specificity_data
-    missing << 'Flattening' unless @flattening_data
-
-    return unless missing.any?
-
-    puts '  Missing benchmarks:'
-    missing.each { |name| puts "    - #{name}" }
-    # :nocov:
+    [
+      ["Native vs #{interpreted.column_label}", interpreted, native],
+      ["Native vs #{yjit.column_label}", yjit, native],
+      ["Native vs #{zjit.column_label}", zjit, native],
+      ['YJIT impact on Pure Ruby', interpreted, yjit],
+      ['ZJIT impact on Pure Ruby', interpreted, zjit],
+      ['ZJIT vs YJIT', yjit, zjit]
+    ]
   end
 
   private
 
+  # Read by the ERB template.
+  attr_reader :metadata, :parsing_data, :serialization_data, :specificity_data, :flattening_data
+
+  def all_data
+    [@parsing_data, @serialization_data, @specificity_data, @flattening_data]
+  end
+
   def load_metadata
     metadata_path = File.join(@results_dir, 'metadata.json')
-    if File.exist?(metadata_path)
-      JSON.parse(File.read(metadata_path))
-    else
-      # :nocov:
-      warn 'Warning: metadata.json not found. Run benchmarks first.'
-      {}
-      # :nocov:
-    end
+    return JSON.parse(File.read(metadata_path)) if File.exist?(metadata_path)
+
+    # :nocov:
+    warn 'Warning: metadata.json not found. Run benchmarks first.'
+    {}
+    # :nocov:
   end
 
   def load_benchmark_data(name)
@@ -93,137 +99,70 @@ class BenchmarkDocGenerator
     # :nocov:
   end
 
-  # Formatting helpers for ERB template
+  # Template helpers
 
-  def format_ips(result, short: false)
-    ips = result['central_tendency']
-
-    formatted = if ips >= 1_000_000
-                  "#{(ips / 1_000_000.0).round(2)}M"
-                elsif ips >= 1_000
-                  "#{(ips / 1_000.0).round(2)}K"
-                else
-                  ips.round(1).to_s
-                end
-
-    if short
-      "#{formatted} i/s"
-    else
-      time_per_op = format_time_per_op(result)
-      "#{formatted} i/s (#{time_per_op})"
-    end
-  end
-
-  def format_time_per_op(result)
-    ips = result['central_tendency']
-    time_us = 1_000_000.0 / ips
-
-    if time_us >= 1_000
-      "#{(time_us / 1_000).round(2)} ms"
-    else
-      "#{time_us.round(2)} μs"
-    end
-  end
-
-  def format_speedup(speedup)
-    return "N/A" if speedup.nil?
-    return "#{speedup.round(2)}x faster" if speedup >= 1
-
-    "#{(1.0 / speedup).round(2)}x slower"
-  end
-
-  def format_number(num)
-    num.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
-  end
-
-  # Calculate speedup using SpeedupCalculator (proper per-test-case averaging)
-  # @param data [Hash] Benchmark data with 'results' and 'metadata'
-  # @param baseline_matcher [Proc] Matcher for baseline results
-  # @param comparison_matcher [Proc] Matcher for comparison results
-  # @param test_case_key [Symbol] Key in test_cases to match test case IDs
-  # @return [Float, nil] Average speedup or nil if no matches
-  def calculate_speedup(data, baseline_matcher:, comparison_matcher:, test_case_key: nil)
-    return nil unless data && data['results'] && data['metadata']
-
-    test_cases = data['metadata']['test_cases'] || []
-
-    calculator = SpeedupCalculator.new(
+  # One row per test case, one column per implementation that produced
+  # measurements.
+  def result_table(data, test_cases: nil, row_header: 'Test Case')
+    ResultTable.new(
       results: data['results'],
-      test_cases: test_cases,
-      baseline_matcher: baseline_matcher,
-      comparison_matcher: comparison_matcher,
-      test_case_key: test_case_key
-    )
-
-    speedup_stats = calculator.calculate
-    speedup_stats ? speedup_stats['avg'] : nil
+      test_cases: test_cases || data['metadata']['test_cases'],
+      implementations: Implementation.all,
+      row_header: row_header
+    ).to_markdown
   end
 
-  # Generate speedup table for a benchmark
-  # @param data [Hash] Benchmark data with 'results' and 'metadata'
-  # @param test_case_key [Symbol] Key in test_cases to match test case IDs
-  # @return [String] Markdown table rows for speedups
-  def speedup_rows(data, test_case_key:)
+  # What turning a feature on costs, per implementation.
+  def overhead_table(data, without_id:, with_id:)
+    OverheadTable.new(
+      results: data['results'],
+      implementations: Implementation.all,
+      without_id: without_id,
+      with_id: with_id
+    ).to_markdown
+  end
+
+  def speedup_rows(data)
     return '' unless data
 
-    rows = []
-
-    # Native vs Pure (no YJIT) - from pre-calculated metadata if available
-    if data['metadata'] && data['metadata']['speedups']
-      rows << "| Native vs Pure (no YJIT) | #{format_speedup(data['metadata']['speedups']['avg'])} (avg) |"
-    end
-
-    # Native vs Pure (YJIT)
-    native_vs_pure_yjit = calculate_speedup(
-      data,
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_with_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-      test_case_key: test_case_key
-    )
-    rows << "| Native vs Pure (YJIT) | #{format_speedup(native_vs_pure_yjit)} (avg) |" if native_vs_pure_yjit
-
-    # Native vs Pure (ZJIT)
-    native_vs_pure_zjit = calculate_speedup(
-      data,
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_with_zjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-      test_case_key: test_case_key
-    )
-    rows << "| Native vs Pure (ZJIT) | #{format_speedup(native_vs_pure_zjit)} (avg) |" if native_vs_pure_zjit
-
-    # YJIT impact on Pure Ruby
-    yjit_impact = calculate_speedup(
-      data,
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_pure_with_yjit,
-      test_case_key: test_case_key
-    )
-    rows << "| YJIT impact on Pure Ruby | #{format_speedup(yjit_impact)} (avg) |" if yjit_impact
-
-    # ZJIT impact on Pure Ruby
-    zjit_impact = calculate_speedup(
-      data,
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_pure_with_zjit,
-      test_case_key: test_case_key
-    )
-    rows << "| ZJIT impact on Pure Ruby | #{format_speedup(zjit_impact)} (avg) |" if zjit_impact
-
-    # ZJIT vs YJIT - the capstone comparison: does the new JIT close the gap?
-    zjit_vs_yjit = calculate_speedup(
-      data,
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_with_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_pure_with_zjit,
-      test_case_key: test_case_key
-    )
-    rows << "| ZJIT vs YJIT | #{format_speedup(zjit_vs_yjit)} (avg) |" if zjit_vs_yjit
-
-    rows.join("\n")
+    self.class.speedup_comparisons.filter_map do |label, baseline, comparison|
+      speedup = average_speedup(data, baseline: baseline, comparison: comparison)
+      "| #{label} | #{format_speedup(speedup)} (avg) |" if speedup
+    end.join("\n")
   end
 
-  # Access instance variables for ERB
-  attr_reader :metadata, :parsing_data, :serialization_data,
-              :specificity_data, :flattening_data
+  # @return [Float, nil] mean speedup across the test cases both
+  #   implementations measured, or nil if they share none
+  def average_speedup(data, baseline:, comparison:)
+    return nil unless data && data['results'] && data['metadata']
+
+    SpeedupCalculator.new(
+      results: data['results'],
+      test_cases: data['metadata']['test_cases'] || [],
+      baseline: baseline,
+      comparison: comparison
+    ).calculate&.fetch('avg')
+  end
+
+  # :nocov:
+  def report_no_data
+    puts 'Warning: No benchmark data found. Run benchmarks first: rake benchmark'
+    puts 'Available data files:'
+    Dir.glob(File.join(@results_dir, '*.json')).each { |file| puts "  - #{File.basename(file)}" }
+  end
+
+  def report_coverage
+    included, missing = BENCHMARKS.zip(all_data).partition(&:last)
+
+    puts 'Generated BENCHMARKS.md'
+    puts '  Included benchmarks:'
+    included.map(&:first).each { |name| puts "    - #{name.capitalize}" }
+    return if missing.empty?
+
+    puts '  Missing benchmarks:'
+    missing.map(&:first).each { |name| puts "    - #{name.capitalize}" }
+  end
+  # :nocov:
 end
 
 # Run if called directly
@@ -235,7 +174,6 @@ if __FILE__ == $PROGRAM_NAME
     exit 1
   end
 
-  generator = BenchmarkDocGenerator.new
-  generator.generate
+  BenchmarkDocGenerator.new.generate
 end
 # :nocov:

--- a/scripts/generate_benchmarks_md.rb
+++ b/scripts/generate_benchmarks_md.rb
@@ -127,7 +127,9 @@ class BenchmarkDocGenerator
 
   def format_speedup(speedup)
     return "N/A" if speedup.nil?
-    "#{speedup.round(2)}x faster"
+    return "#{speedup.round(2)}x faster" if speedup >= 1
+
+    "#{(1.0 / speedup).round(2)}x slower"
   end
 
   def format_number(num)
@@ -180,6 +182,15 @@ class BenchmarkDocGenerator
     )
     rows << "| Native vs Pure (YJIT) | #{format_speedup(native_vs_pure_yjit)} (avg) |" if native_vs_pure_yjit
 
+    # Native vs Pure (ZJIT)
+    native_vs_pure_zjit = calculate_speedup(
+      data,
+      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_with_zjit,
+      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
+      test_case_key: test_case_key
+    )
+    rows << "| Native vs Pure (ZJIT) | #{format_speedup(native_vs_pure_zjit)} (avg) |" if native_vs_pure_zjit
+
     # YJIT impact on Pure Ruby
     yjit_impact = calculate_speedup(
       data,
@@ -188,6 +199,24 @@ class BenchmarkDocGenerator
       test_case_key: test_case_key
     )
     rows << "| YJIT impact on Pure Ruby | #{format_speedup(yjit_impact)} (avg) |" if yjit_impact
+
+    # ZJIT impact on Pure Ruby
+    zjit_impact = calculate_speedup(
+      data,
+      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
+      comparison_matcher: SpeedupCalculator::Matchers.cataract_pure_with_zjit,
+      test_case_key: test_case_key
+    )
+    rows << "| ZJIT impact on Pure Ruby | #{format_speedup(zjit_impact)} (avg) |" if zjit_impact
+
+    # ZJIT vs YJIT - the capstone comparison: does the new JIT close the gap?
+    zjit_vs_yjit = calculate_speedup(
+      data,
+      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_with_yjit,
+      comparison_matcher: SpeedupCalculator::Matchers.cataract_pure_with_zjit,
+      test_case_key: test_case_key
+    )
+    rows << "| ZJIT vs YJIT | #{format_speedup(zjit_vs_yjit)} (avg) |" if zjit_vs_yjit
 
     rows.join("\n")
   end

--- a/test/fixtures/benchmarks/parsing_sample.json
+++ b/test/fixtures/benchmarks/parsing_sample.json
@@ -5,70 +5,137 @@
     "test_cases": [
       {
         "name": "Small CSS (64 lines, 1.0KB)",
-        "fixture": "CSS1",
+        "id": "small",
         "lines": 64,
-        "bytes": 1061,
-        "speedup": 10.85
+        "bytes": 1061
       },
       {
         "name": "Medium CSS with @media (139 lines, 1.6KB)",
-        "fixture": "CSS2",
+        "id": "medium with @media",
         "lines": 139,
-        "bytes": 1679,
-        "speedup": 12.87
+        "bytes": 1679
       }
     ],
-    "speedups": {
-      "min": 10.85,
-      "max": 12.87,
-      "avg": 11.86
-    }
+    "error_checking": [
+      {
+        "name": "Medium CSS (139 lines) - no error checking",
+        "id": "error checking off"
+      },
+      {
+        "name": "Medium CSS (139 lines) - with error checking",
+        "id": "error checking on"
+      }
+    ]
   },
   "timestamp": "2025-10-30T16:01:43-05:00",
   "results": [
     {
-      "name": "pure_without_yjit: CSS1",
-      "implementation": "pure_without_yjit",
-      "central_tendency": 6253.617340248006,
-      "ips": 6253.617340248006,
-      "error": 63,
-      "stddev": 63,
-      "microseconds": 5069278.0,
-      "iterations": 31698,
-      "cycles": 587
-    },
-    {
-      "name": "native: CSS1",
-      "implementation": "native",
+      "name": "cataract: small",
+      "implementation": "native_none",
+      "backend": "native",
+      "jit": "none",
       "central_tendency": 67860.26856079814,
       "ips": 67860.26856079814,
-      "error": 536,
-      "stddev": 536,
-      "microseconds": 5023642.0,
-      "iterations": 340884,
-      "cycles": 6684
+      "jit_stats": {}
     },
     {
-      "name": "pure_without_yjit: CSS2",
-      "implementation": "pure_without_yjit",
-      "central_tendency": 3446.4007088523126,
-      "ips": 3446.4007088523126,
-      "error": 33,
-      "stddev": 33,
-      "microseconds": 5076214.0,
-      "iterations": 17493,
-      "cycles": 343
+      "name": "cataract pure: small",
+      "implementation": "pure_none",
+      "backend": "pure",
+      "jit": "none",
+      "central_tendency": 6253.617340248006,
+      "ips": 6253.617340248006,
+      "jit_stats": {}
     },
     {
-      "name": "native: CSS2",
-      "implementation": "native",
+      "name": "cataract pure: small",
+      "implementation": "pure_yjit",
+      "backend": "pure",
+      "jit": "yjit",
+      "central_tendency": 25014.46936099202,
+      "ips": 25014.46936099202,
+      "jit_stats": { "compiled_iseq_count": 412, "failed_iseq_count": 0 }
+    },
+    {
+      "name": "cataract pure: small",
+      "implementation": "pure_zjit",
+      "backend": "pure",
+      "jit": "zjit",
+      "central_tendency": 12507.234680496012,
+      "ips": 12507.234680496012,
+      "jit_stats": { "compiled_iseq_count": 208, "failed_iseq_count": 3 }
+    },
+    {
+      "name": "cataract: medium with @media",
+      "implementation": "native_none",
+      "backend": "native",
+      "jit": "none",
       "central_tendency": 44357.90385806872,
       "ips": 44357.90385806872,
-      "error": 404,
-      "stddev": 404,
-      "microseconds": 5069630.0,
-      "iterations": 224859,
-      "cycles": 4409
+      "jit_stats": {}
+    },
+    {
+      "name": "cataract pure: medium with @media",
+      "implementation": "pure_none",
+      "backend": "pure",
+      "jit": "none",
+      "central_tendency": 3446.4007088523126,
+      "ips": 3446.4007088523126,
+      "jit_stats": {}
+    },
+    {
+      "name": "cataract pure: medium with @media",
+      "implementation": "pure_yjit",
+      "backend": "pure",
+      "jit": "yjit",
+      "central_tendency": 13785.60283540925,
+      "ips": 13785.60283540925,
+      "jit_stats": { "compiled_iseq_count": 412, "failed_iseq_count": 0 }
+    },
+    {
+      "name": "cataract pure: medium with @media",
+      "implementation": "pure_zjit",
+      "backend": "pure",
+      "jit": "zjit",
+      "central_tendency": 6892.801417704625,
+      "ips": 6892.801417704625,
+      "jit_stats": { "compiled_iseq_count": 208, "failed_iseq_count": 3 }
+    },
+    {
+      "name": "cataract: error checking off",
+      "implementation": "native_none",
+      "backend": "native",
+      "jit": "none",
+      "central_tendency": 44000.0,
+      "ips": 44000.0,
+      "jit_stats": {}
+    },
+    {
+      "name": "cataract: error checking on",
+      "implementation": "native_none",
+      "backend": "native",
+      "jit": "none",
+      "central_tendency": 43120.0,
+      "ips": 43120.0,
+      "jit_stats": {}
+    },
+    {
+      "name": "cataract pure: error checking off",
+      "implementation": "pure_none",
+      "backend": "pure",
+      "jit": "none",
+      "central_tendency": 3400.0,
+      "ips": 3400.0,
+      "jit_stats": {}
+    },
+    {
+      "name": "cataract pure: error checking on",
+      "implementation": "pure_none",
+      "backend": "pure",
+      "jit": "none",
+      "central_tendency": 3060.0,
+      "ips": 3060.0,
+      "jit_stats": {}
     }
   ]
 }

--- a/test/support/entrypoint_stub.rb
+++ b/test/support/entrypoint_stub.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Preloaded with `ruby -r` ahead of a benchmark script to answer one question:
+# does running this file actually start a benchmark?
+#
+# Replacing .run means the answer comes back in milliseconds instead of by
+# letting the real benchmark run. A script that defines its class but never
+# invokes it prints nothing.
+require_relative '../../benchmarks/benchmark_harness'
+
+class BenchmarkHarness
+  class << self
+    def run(*, **)
+      puts "ENTRYPOINT #{name}"
+      exit 0
+    end
+  end
+end

--- a/test/support/fake_benchmark_worker.rb
+++ b/test/support/fake_benchmark_worker.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# A benchmark worker that measures nothing meaningful, on purpose.
+#
+# It exists so the harness plumbing - launching one subprocess per
+# Implementation, verifying each landed in the configuration it was asked for,
+# stamping results, combining them, computing speedups - can be tested in
+# seconds instead of by running the real benchmarks.
+require_relative '../../benchmarks/benchmark_harness'
+require_relative '../../benchmarks/worker_helpers'
+
+$LOAD_PATH.unshift File.expand_path('../../lib', __dir__)
+
+module FakeTests
+  def self.metadata
+    { 'test_cases' => [{ 'name' => 'Tiny', 'id' => 'tiny' }] }
+  end
+
+  def call
+    benchmark('tiny') do |x|
+      # As short as benchmark-ips allows: this measures the harness, not Ruby.
+      x.config(time: 0.01, warmup: 0)
+      x.report(result_name('tiny')) { 1 + 1 }
+    end
+  end
+end
+
+class FakeWorkerBenchmark < BenchmarkHarness
+  include FakeTests
+  include WorkerHelpers
+
+  def self.benchmark_name
+    'fake'
+  end
+
+  def self.description
+    'Harness plumbing check'
+  end
+
+  def self.metadata
+    FakeTests.metadata
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'cataract'
+  FakeWorkerBenchmark.run(skip_finalize: true)
+end

--- a/test/support/fake_vm.rb
+++ b/test/support/fake_vm.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Stands in for RubyVM so JIT detection can be exercised for every mode,
+# rather than only the one the test process happens to be running under.
+#
+# RubyMode only ever asks a VM three things - does the constant exist, hand
+# it over, and is it enabled - so that is the whole surface.
+class FakeVM
+  # A stand-in for RubyVM::YJIT / RubyVM::ZJIT.
+  class FakeJit
+    def initialize(enabled:, stats: {})
+      @enabled = enabled
+      @stats = stats
+    end
+
+    attr_reader :stats
+
+    def enabled?
+      @enabled
+    end
+
+    # YJIT and ZJIT name this differently; RubyMode knows which to call.
+    alias runtime_stats stats
+  end
+
+  # A VM with no JIT support compiled in at all.
+  def self.without_jits
+    new({})
+  end
+
+  # @param jits [Hash{Symbol => FakeJit}] constants this VM defines
+  def initialize(jits)
+    @jits = jits
+  end
+
+  # @param name [Symbol] e.g. :YJIT
+  def self.with(name, enabled: true, stats: {})
+    new(name => FakeJit.new(enabled: enabled, stats: stats))
+  end
+
+  def const_defined?(name)
+    @jits.key?(name)
+  end
+
+  def const_get(name)
+    @jits.fetch(name)
+  end
+end

--- a/test/test_backend.rb
+++ b/test/test_backend.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../benchmarks/backend'
+
+class TestBackend < Minitest::Test
+  def test_all_backends_in_display_order
+    assert_equal %i[native pure], Backend::ALL.map(&:id)
+  end
+
+  def test_fetch_accepts_symbol_or_string
+    assert_same Backend::PURE, Backend.fetch(:pure)
+    assert_same Backend::PURE, Backend.fetch('pure')
+  end
+
+  def test_fetch_raises_on_unknown_backend
+    error = assert_raises(ArgumentError) { Backend.fetch(:jruby) }
+
+    assert_includes error.message, 'unknown backend'
+    assert_includes error.message, 'native, pure'
+  end
+
+  def test_native_declares_one_mode_because_a_jit_cannot_speed_up_c
+    assert_equal [RubyMode::NO_JIT], Backend::NATIVE.modes
+  end
+
+  def test_pure_declares_every_jit_mode
+    assert_equal RubyMode::ALL, Backend::PURE.modes
+  end
+
+  def test_selection_env_requests_the_right_backend_at_require_time
+    assert_equal '1', Backend::PURE.selection_env[Backend::SELECTION_ENV_VAR]
+    assert_nil Backend::NATIVE.selection_env.fetch(Backend::SELECTION_ENV_VAR)
+  end
+
+  def test_active_maps_what_cataract_loaded_onto_a_backend
+    assert_same Backend::PURE, Backend.active(:ruby)
+    assert_same Backend::NATIVE, Backend.active(:native)
+  end
+
+  def test_active_defaults_to_the_cataract_actually_loaded_here
+    expected = Cataract::IMPLEMENTATION == :ruby ? Backend::PURE : Backend::NATIVE
+
+    assert_same expected, Backend.active
+  end
+
+  def test_expected_is_nil_when_unset_so_workers_can_run_standalone
+    assert_nil Backend.expected({})
+  end
+
+  def test_expected_reads_the_backend_the_parent_asked_for
+    assert_same Backend::PURE, Backend.expected(Backend::ENV_VAR => 'pure')
+  end
+
+  def test_verify_returns_the_actual_backend_when_it_matches
+    assert_same Backend::PURE, Backend.verify!(actual: Backend::PURE, expected: Backend::PURE)
+  end
+
+  def test_verify_skips_the_check_when_nothing_was_expected
+    assert_same Backend::NATIVE, Backend.verify!(actual: Backend::NATIVE, expected: nil)
+  end
+
+  def test_verify_raises_when_the_wrong_backend_loaded
+    # Measuring the C extension while believing it's pure Ruby is exactly as
+    # misleading as measuring the interpreter while believing it's ZJIT.
+    error = assert_raises(Backend::Mismatch) do
+      Backend.verify!(actual: Backend::NATIVE, expected: Backend::PURE)
+    end
+
+    assert_includes error.message, 'expected to have loaded the cataract pure backend'
+    assert_includes error.message, 'reports cataract is loaded'
+  end
+end

--- a/test/test_benchmark_doc_generator.rb
+++ b/test/test_benchmark_doc_generator.rb
@@ -55,7 +55,17 @@ class TestBenchmarkDocGenerator < Minitest::Test
     # Check parsing section exists
     assert_includes content, '## CSS Parsing'
     assert_includes content, 'Pure (no YJIT)'
+    assert_includes content, 'Pure (ZJIT)'
     assert_includes content, 'faster'
+  end
+
+  def test_renders_slower_speedup_as_slower_not_faster
+    generator = BenchmarkDocGenerator.new(results_dir: @results_dir, output_path: @output_path, verbose: false)
+
+    # A speedup < 1 (comparison slower than baseline) must never be reported as "faster"
+    refute_includes generator.send(:format_speedup, 0.8), 'faster'
+    assert_includes generator.send(:format_speedup, 0.8), 'slower'
+    assert_includes generator.send(:format_speedup, 2.0), 'faster'
   end
 
   def test_handles_missing_benchmarks

--- a/test/test_benchmark_doc_generator.rb
+++ b/test/test_benchmark_doc_generator.rb
@@ -54,18 +54,40 @@ class TestBenchmarkDocGenerator < Minitest::Test
 
     # Check parsing section exists
     assert_includes content, '## CSS Parsing'
-    assert_includes content, 'Pure (no YJIT)'
+    assert_includes content, 'Pure (no JIT)'
+    assert_includes content, 'Pure (YJIT)'
     assert_includes content, 'Pure (ZJIT)'
     assert_includes content, 'faster'
   end
 
-  def test_renders_slower_speedup_as_slower_not_faster
+  def test_column_headings_come_from_the_implementations
     generator = BenchmarkDocGenerator.new(results_dir: @results_dir, output_path: @output_path, verbose: false)
+    generator.generate
 
-    # A speedup < 1 (comparison slower than baseline) must never be reported as "faster"
-    refute_includes generator.send(:format_speedup, 0.8), 'faster'
-    assert_includes generator.send(:format_speedup, 0.8), 'slower'
-    assert_includes generator.send(:format_speedup, 2.0), 'faster'
+    expected = "| #{Implementation.all.map(&:column_label).join(' | ')} |"
+
+    assert_includes File.read(@output_path), expected
+  end
+
+  def test_reports_the_zjit_versus_yjit_comparison
+    generator = BenchmarkDocGenerator.new(results_dir: @results_dir, output_path: @output_path, verbose: false)
+    generator.generate
+
+    content = File.read(@output_path)
+
+    # The fixture has ZJIT at half YJIT's rate throughout.
+    assert_includes content, '| ZJIT vs YJIT | 2.0x slower (avg) |'
+  end
+
+  def test_reports_error_checking_overhead_per_implementation
+    generator = BenchmarkDocGenerator.new(results_dir: @results_dir, output_path: @output_path, verbose: false)
+    generator.generate
+
+    content = File.read(@output_path)
+
+    assert_includes content, '| Implementation | Overhead |'
+    assert_includes content, '| Native | 2.0% slower |'
+    assert_includes content, '| Pure (no JIT) | 11.1% slower |'
   end
 
   def test_handles_missing_benchmarks

--- a/test/test_benchmark_formatting.rb
+++ b/test/test_benchmark_formatting.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../benchmarks/benchmark_formatting'
+
+class TestBenchmarkFormatting < Minitest::Test
+  include BenchmarkFormatting
+
+  def result(ips)
+    { 'central_tendency' => ips }
+  end
+
+  def test_scales_rates_to_thousands_and_millions
+    assert_equal '435.4 i/s', format_ips(result(435.4), short: true)
+    assert_equal '13.84K i/s', format_ips(result(13_840.0), short: true)
+    assert_equal '1.91M i/s', format_ips(result(1_910_000.0), short: true)
+  end
+
+  def test_long_form_adds_time_per_operation
+    assert_equal '10.0K i/s (100.0 μs)', format_ips(result(10_000.0))
+    assert_equal '500.0 i/s (2.0 ms)', format_ips(result(500.0))
+  end
+
+  def test_a_missing_measurement_renders_as_na
+    assert_equal BenchmarkFormatting::MISSING, format_ips(nil)
+    assert_equal BenchmarkFormatting::MISSING, format_speedup(nil)
+    assert_equal BenchmarkFormatting::MISSING, format_overhead(nil, result(10.0))
+  end
+
+  def test_a_ratio_below_one_reads_as_slower_not_faster
+    assert_equal '1.79x slower', format_speedup(0.5596)
+    refute_includes format_speedup(0.8), 'faster'
+  end
+
+  def test_a_ratio_at_or_above_one_reads_as_faster
+    assert_equal '2.0x faster', format_speedup(2.0)
+    assert_equal '1.0x faster', format_speedup(1.0)
+  end
+
+  def test_overhead_is_the_cost_of_turning_the_feature_on
+    assert_equal '10.0% slower', format_overhead(result(110.0), result(100.0))
+  end
+
+  def test_overhead_within_a_percent_is_reported_as_noise
+    assert_equal '~0% (within noise)', format_overhead(result(100.5), result(100.0))
+  end
+
+  def test_overhead_that_comes_out_negative_is_flagged_as_unexpected
+    assert_equal '4.8% faster (unexpected)', format_overhead(result(100.0), result(105.0))
+  end
+end

--- a/test/test_benchmark_implementation.rb
+++ b/test/test_benchmark_implementation.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require_relative 'support/fake_vm'
 require_relative '../benchmarks/implementation'
 
 # Covers the benchmark harness's Implementation (a backend paired with a Ruby
@@ -22,6 +23,20 @@ class TestBenchmarkImplementation < Minitest::Test
     Implementation.all.each do |implementation|
       assert_includes implementation.backend.modes, implementation.mode
     end
+  end
+
+  def test_available_drops_variants_this_ruby_cannot_run
+    # A 3.x has YJIT but no ZJIT, so it benchmarks three variants, not four.
+    available = Implementation.available(FakeVM.with(:YJIT)).map(&:id)
+
+    assert_equal %i[native_none pure_none pure_yjit], available
+  end
+
+  def test_available_is_everything_when_the_ruby_has_both_jits
+    ruby_vm = FakeVM.new(YJIT: FakeVM::FakeJit.new(enabled: false),
+                         ZJIT: FakeVM::FakeJit.new(enabled: false))
+
+    assert_equal Implementation.all.map(&:id), Implementation.available(ruby_vm).map(&:id)
   end
 
   def test_id_pairs_both_axes

--- a/test/test_benchmark_implementation.rb
+++ b/test/test_benchmark_implementation.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../benchmarks/implementation'
+
+# Covers the benchmark harness's Implementation (a backend paired with a Ruby
+# VM configuration), not Cataract::IMPLEMENTATION - see test_implementation.rb
+# for that.
+class TestBenchmarkImplementation < Minitest::Test
+  def setup
+    @native = Implementation.find(:native, :none)
+    @interpreted = Implementation.find(:pure, :none)
+    @yjit = Implementation.find(:pure, :yjit)
+    @zjit = Implementation.find(:pure, :zjit)
+  end
+
+  def test_all_is_every_backend_crossed_with_the_modes_it_declares
+    assert_equal %i[native_none pure_none pure_yjit pure_zjit], Implementation.all.map(&:id)
+  end
+
+  def test_all_only_contains_variants_their_backend_declares
+    Implementation.all.each do |implementation|
+      assert_includes implementation.backend.modes, implementation.mode
+    end
+  end
+
+  def test_id_pairs_both_axes
+    assert_equal :pure_zjit, @zjit.id
+    assert_equal :native_none, @native.id
+  end
+
+  def test_label_omits_the_mode_when_the_backend_only_runs_one_way
+    assert_equal 'cataract', @native.label
+    assert_equal 'cataract pure (ZJIT)', @zjit.label
+    assert_equal 'cataract pure (no JIT)', @interpreted.label
+  end
+
+  def test_column_label_matches_the_benchmarks_md_headings
+    assert_equal 'Native', @native.column_label
+    assert_equal 'Pure (no JIT)', @interpreted.column_label
+    assert_equal 'Pure (YJIT)', @yjit.column_label
+    assert_equal 'Pure (ZJIT)', @zjit.column_label
+  end
+
+  def test_ruby_command_carries_the_modes_flags
+    assert_equal ['ruby', '--zjit', 'worker.rb'], @zjit.ruby_command('worker.rb')
+    assert_equal ['ruby', '--disable-yjit', 'worker.rb'], @native.ruby_command('worker.rb')
+  end
+
+  def test_env_states_the_expectation_on_both_axes
+    env = @zjit.env
+
+    assert_equal '1', env[Backend::SELECTION_ENV_VAR]
+    assert_equal 'pure', env[Backend::ENV_VAR]
+    assert_equal 'zjit', env[RubyMode::ENV_VAR]
+  end
+
+  def test_env_unsets_the_pure_selector_for_the_native_backend
+    assert_nil @native.env.fetch(Backend::SELECTION_ENV_VAR)
+    assert_equal 'native', @native.env[Backend::ENV_VAR]
+  end
+
+  def test_result_fields_carry_both_axes_separately
+    assert_equal({ 'implementation' => 'pure_zjit', 'backend' => 'pure', 'jit' => 'zjit' },
+                 @zjit.result_fields)
+  end
+
+  def test_produced_matches_only_its_own_rows
+    row = { 'implementation' => 'pure_zjit' }
+
+    assert @zjit.produced?(row)
+    refute @yjit.produced?(row)
+    refute @interpreted.produced?(row)
+  end
+
+  def test_value_equality_so_implementations_can_be_compared_and_hashed
+    assert_equal Implementation.find(:pure, :zjit), @zjit
+    refute_equal @yjit, @zjit
+    assert_equal 1, [Implementation.find(:pure, :zjit), @zjit].uniq.size
+  end
+
+  def test_current_pairs_the_loaded_backend_with_the_active_mode
+    current = Implementation.current(env: {}, backend: Backend::PURE, mode: RubyMode::ZJIT)
+
+    assert_equal @zjit, current
+  end
+
+  def test_current_accepts_a_run_matching_what_was_asked_for
+    env = { Backend::ENV_VAR => 'pure', RubyMode::ENV_VAR => 'zjit' }
+
+    assert_equal @zjit, Implementation.current(env: env, backend: Backend::PURE, mode: RubyMode::ZJIT)
+  end
+
+  def test_current_refuses_a_run_under_a_mislabeled_jit
+    env = { Backend::ENV_VAR => 'pure', RubyMode::ENV_VAR => 'zjit' }
+
+    assert_raises(RubyMode::Mismatch) do
+      Implementation.current(env: env, backend: Backend::PURE, mode: RubyMode::NO_JIT)
+    end
+  end
+
+  def test_current_refuses_a_run_under_a_mislabeled_backend
+    env = { Backend::ENV_VAR => 'pure', RubyMode::ENV_VAR => 'none' }
+
+    assert_raises(Backend::Mismatch) do
+      Implementation.current(env: env, backend: Backend::NATIVE, mode: RubyMode::NO_JIT)
+    end
+  end
+end

--- a/test/test_benchmark_plumbing.rb
+++ b/test/test_benchmark_plumbing.rb
@@ -53,15 +53,22 @@ class TestBenchmarkPlumbing < Minitest::Test
     end
   end
 
+  # Only the variants this Ruby can run: ZJIT is Ruby 4.0+, and YJIT can be
+  # absent from a build, so `ruby --zjit` on a 3.x is an error rather than a
+  # variant. The harness measures what it can and the columns follow.
+  def expected_implementations
+    Implementation.available
+  end
+
   def test_runs_one_subprocess_per_implementation
     produced = combined['results'].map { |row| row['implementation'] }.uniq.sort
 
-    assert_equal Implementation.all.map { |i| i.id.to_s }.sort, produced
+    assert_equal expected_implementations.map { |i| i.id.to_s }.sort, produced
   end
 
   def test_every_result_carries_both_axes
     combined['results'].each do |row|
-      implementation = Implementation.all.find { |i| i.produced?(row) }
+      implementation = expected_implementations.find { |i| i.produced?(row) }
 
       refute_nil implementation, "unrecognized implementation #{row['implementation'].inspect}"
       assert_equal implementation.backend.id.to_s, row['backend']
@@ -73,8 +80,8 @@ class TestBenchmarkPlumbing < Minitest::Test
     # Guards the case a timing alone can't distinguish: a JIT that was enabled
     # but never compiled the code being measured.
     jitted = combined['results'].reject { |row| row['jit'] == 'none' }
+    skip 'no JIT available on this Ruby' if jitted.empty?
 
-    refute_empty jitted
     jitted.each do |row|
       assert_operator row.dig('jit_stats', 'compiled_iseq_count'), :>, 0,
                       "#{row['implementation']} reported no compiled iseqs"

--- a/test/test_benchmark_plumbing.rb
+++ b/test/test_benchmark_plumbing.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'tmpdir'
+require_relative '../benchmarks/benchmark_harness'
+require_relative '../benchmarks/result_set'
+require_relative '../benchmarks/results_directory'
+
+# End-to-end test of the harness machinery against a fake benchmark that
+# measures nothing. Real subprocesses, real result files, real combining -
+# just no expensive workload, so this runs in seconds.
+#
+# This covers the seam that unit tests can't: a benchmark that never launches,
+# a variant that lands in the wrong configuration, results that don't get
+# stamped or combined.
+class TestBenchmarkPlumbing < Minitest::Test
+  WORKER = File.expand_path('support/fake_benchmark_worker.rb', __dir__)
+
+  class FakeBenchmark < BenchmarkHarness
+    def self.benchmark_name
+      'fake'
+    end
+
+    def self.description
+      'Harness plumbing check'
+    end
+
+    def self.metadata
+      { 'test_cases' => [{ 'name' => 'Tiny', 'id' => 'tiny' }] }
+    end
+
+    def call
+      run_all_variants(WORKER)
+    end
+  end
+
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @results = ResultsDirectory.new(@tmpdir).create
+    @combined = nil
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  # Runs the whole pipeline once and memoizes, since every assertion below
+  # inspects a different part of the same output.
+  def combined
+    @combined ||= begin
+      capture_io { FakeBenchmark.new(results: @results).call }
+      @results.read('fake.json')
+    end
+  end
+
+  def test_runs_one_subprocess_per_implementation
+    produced = combined['results'].map { |row| row['implementation'] }.uniq.sort
+
+    assert_equal Implementation.all.map { |i| i.id.to_s }.sort, produced
+  end
+
+  def test_every_result_carries_both_axes
+    combined['results'].each do |row|
+      implementation = Implementation.all.find { |i| i.produced?(row) }
+
+      refute_nil implementation, "unrecognized implementation #{row['implementation'].inspect}"
+      assert_equal implementation.backend.id.to_s, row['backend']
+      assert_equal implementation.mode.id.to_s, row['jit']
+    end
+  end
+
+  def test_jit_runs_report_that_they_compiled_something
+    # Guards the case a timing alone can't distinguish: a JIT that was enabled
+    # but never compiled the code being measured.
+    jitted = combined['results'].reject { |row| row['jit'] == 'none' }
+
+    refute_empty jitted
+    jitted.each do |row|
+      assert_operator row.dig('jit_stats', 'compiled_iseq_count'), :>, 0,
+                      "#{row['implementation']} reported no compiled iseqs"
+    end
+  end
+
+  def test_interpreter_runs_report_no_jit_stats
+    combined['results'].select { |row| row['jit'] == 'none' }.each do |row|
+      assert_empty row['jit_stats']
+    end
+  end
+
+  def test_result_names_follow_the_label_colon_id_convention
+    combined['results'].each do |row|
+      assert_equal 'tiny', ResultSet.test_case_id(row)
+    end
+  end
+
+  def test_computes_speedups_between_the_configured_pair
+    assert_operator combined['metadata']['speedups']['avg'], :>, 0
+  end
+
+  def test_carries_benchmark_identity_into_the_combined_file
+    assert_equal 'fake', combined['name']
+    assert_equal 'Harness plumbing check', combined['description']
+  end
+
+  def test_cleans_up_the_per_variant_worker_files
+    combined # run the pipeline
+
+    # metadata.json is written by each worker's setup and is meant to survive;
+    # the per-variant fake_<impl>_<case>.json files are not.
+    leftovers = @results.glob('fake_*.json').map { |path| File.basename(path) }
+
+    assert_empty leftovers
+  end
+
+  def test_writes_nothing_outside_the_results_directory_it_was_given
+    combined
+
+    refute_path_exists File.join(ResultsDirectory::DEFAULT_PATH, 'fake.json')
+  end
+
+  class FailingBenchmark < FakeBenchmark
+    def call
+      run_all_variants(File.expand_path('support/no_such_worker.rb', __dir__))
+    end
+  end
+
+  # Every script `rake benchmark` invokes has to actually start a benchmark
+  # when executed. A file that defines its class but never calls .run exits 0
+  # immediately, and the whole rake task then "succeeds" in silence.
+  ORCHESTRATORS = %w[parsing serialization specificity flattening].freeze
+  STUB = File.expand_path('support/entrypoint_stub.rb', __dir__)
+
+  ORCHESTRATORS.each do |name|
+    define_method(:"test_#{name}_orchestrator_starts_when_executed") do
+      assert_starts_a_benchmark File.expand_path("../benchmarks/benchmark_#{name}.rb", __dir__)
+    end
+
+    define_method(:"test_#{name}_worker_starts_when_executed") do
+      assert_starts_a_benchmark File.expand_path("../benchmarks/benchmark_#{name}_workers.rb", __dir__)
+    end
+  end
+
+  def assert_starts_a_benchmark(script)
+    output = IO.popen([{ 'CATARACT_PURE' => nil }, 'ruby', '-r', STUB, script], err: %i[child out], &:read)
+
+    assert_match(/ENTRYPOINT /, output,
+                 "#{File.basename(script)} exited without starting a benchmark:\n#{output}")
+  end
+
+  def test_a_variant_that_fails_aborts_instead_of_reporting_partial_results
+    error = assert_raises(RuntimeError) do
+      capture_io { FailingBenchmark.new(results: @results).call }
+    end
+
+    assert_match(/benchmark failed/, error.message)
+    refute_path_exists @results.join('fake.json')
+  end
+end

--- a/test/test_result_set.rb
+++ b/test/test_result_set.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../benchmarks/result_set'
+require_relative '../benchmarks/implementation'
+
+class TestResultSet < Minitest::Test
+  def setup
+    @pure = Implementation.find(:pure, :none)
+    @native = Implementation.find(:native, :none)
+  end
+
+  def row(name, implementation, ips)
+    { 'name' => name, 'implementation' => implementation.id.to_s, 'central_tendency' => ips }
+  end
+
+  def test_extracts_the_test_case_id_from_a_result_name
+    assert_equal 'selector lists', ResultSet.test_case_id('name' => 'cataract pure: selector lists')
+  end
+
+  def test_finds_a_measurement_by_test_case_and_implementation
+    set = ResultSet.new([row('cataract pure: small', @pure, 100.0), row('cataract: small', @native, 900.0)])
+
+    assert_in_delta(100.0, set.find('small', @pure)['central_tendency'])
+    assert_in_delta(900.0, set.find('small', @native)['central_tendency'])
+  end
+
+  def test_returns_nil_when_a_pairing_was_never_run
+    set = ResultSet.new([row('cataract pure: small', @pure, 100.0)])
+
+    assert_nil set.find('small', @native)
+    assert_nil set.find('large', @pure)
+  end
+
+  # The regression these exact lookups exist to prevent. Real benchmark ids
+  # overlap: matching by substring silently returned another test case's
+  # numbers, so BENCHMARKS.md published two identical rows for two different
+  # workloads.
+  def test_an_id_never_matches_a_longer_id_that_contains_it
+    set = ResultSet.new([
+                          row('cataract pure: bootstrap_compact', @pure, 300.0),
+                          row('cataract pure: compact', @pure, 1200.0)
+                        ])
+
+    assert_in_delta(1200.0, set.find('compact', @pure)['central_tendency'])
+    assert_in_delta(300.0, set.find('bootstrap_compact', @pure)['central_tendency'])
+  end
+
+  def test_an_id_never_matches_a_longer_id_that_ends_with_it
+    set = ResultSet.new([
+                          row('cataract pure: no_shorthand', @pure, 2840.0),
+                          row('cataract pure: shorthand', @pure, 12_290.0)
+                        ])
+
+    assert_in_delta(12_290.0, set.find('shorthand', @pure)['central_tendency'])
+    assert_in_delta(2840.0, set.find('no_shorthand', @pure)['central_tendency'])
+  end
+
+  def test_implementations_among_keeps_only_those_with_measurements
+    set = ResultSet.new([row('cataract pure: small', @pure, 100.0)])
+
+    assert_equal [@pure], set.implementations_among([@native, @pure])
+  end
+
+  def test_implementations_among_preserves_the_order_it_was_given
+    set = ResultSet.new([row('cataract pure: small', @pure, 100.0), row('cataract: small', @native, 900.0)])
+
+    assert_equal [@native, @pure], set.implementations_among([@native, @pure])
+  end
+
+  def test_tolerates_no_results_at_all
+    set = ResultSet.new(nil)
+
+    assert_empty set.rows
+    assert_nil set.find('small', @pure)
+    assert_empty set.implementations_among([@pure])
+  end
+end

--- a/test/test_result_table.rb
+++ b/test/test_result_table.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../benchmarks/result_table'
+require_relative '../benchmarks/implementation'
+
+class TestResultTable < Minitest::Test
+  def setup
+    @native = Implementation.find(:native, :none)
+    @interpreted = Implementation.find(:pure, :none)
+    @zjit = Implementation.find(:pure, :zjit)
+    @columns = [@native, @interpreted, @zjit]
+  end
+
+  def row(id, implementation, ips)
+    { 'name' => "#{implementation.backend.label}: #{id}", 'implementation' => implementation.id.to_s,
+      'central_tendency' => ips }
+  end
+
+  def table(results, test_cases, **)
+    ResultTable.new(results: results, test_cases: test_cases, implementations: @columns, **).to_markdown
+  end
+
+  def test_headings_come_from_the_implementations_themselves
+    markdown = table([row('small', @native, 1000.0)], [{ 'id' => 'small', 'name' => 'Small CSS' }])
+
+    assert_equal '| Test Case | Native |', markdown.lines.first.chomp
+  end
+
+  def test_row_header_is_configurable
+    markdown = table([row('small', @native, 1000.0)], [{ 'id' => 'small', 'name' => 'Small CSS' }],
+                     row_header: 'Configuration')
+
+    assert_includes markdown.lines.first, '| Configuration |'
+  end
+
+  def test_renders_one_cell_per_implementation
+    results = [row('small', @native, 37_580.0), row('small', @interpreted, 3330.0), row('small', @zjit, 7560.0)]
+
+    markdown = table(results, [{ 'id' => 'small', 'name' => 'Small CSS' }])
+
+    assert_includes markdown, '| Small CSS | 37.58K i/s | 3.33K i/s | 7.56K i/s |'
+  end
+
+  def test_a_pairing_that_was_not_run_renders_as_na
+    results = [row('small', @native, 1000.0), row('small', @interpreted, 100.0), row('small', @zjit, 200.0),
+               row('large', @native, 500.0), row('large', @interpreted, 50.0)]
+
+    markdown = table(results, [{ 'id' => 'large', 'name' => 'Large CSS' }])
+
+    assert_includes markdown, '| Large CSS | 500.0 i/s | 50.0 i/s | N/A |'
+  end
+
+  def test_omits_columns_nothing_was_measured_for
+    markdown = table([row('small', @native, 1000.0)], [{ 'id' => 'small', 'name' => 'Small CSS' }])
+
+    assert_equal '| Test Case | Native |', markdown.lines.first.chomp
+    refute_includes markdown, 'Pure'
+  end
+
+  def test_renders_nothing_when_there_are_no_measurements
+    assert_equal '', table([], [{ 'id' => 'small', 'name' => 'Small CSS' }])
+  end
+
+  # Regression: ids overlap, and matching by substring published one
+  # workload's numbers under another workload's name.
+  def test_a_test_case_never_borrows_a_longer_ids_numbers
+    results = [row('bootstrap_compact', @native, 1050.0), row('compact', @native, 15_900.0)]
+    test_cases = [{ 'id' => 'bootstrap_compact', 'name' => 'to_s (Bootstrap)' },
+                  { 'id' => 'compact', 'name' => 'to_s (Compact utilities)' }]
+
+    markdown = table(results, test_cases)
+
+    assert_includes markdown, '| to_s (Bootstrap) | 1.05K i/s |'
+    assert_includes markdown, '| to_s (Compact utilities) | 15.9K i/s |'
+  end
+end
+
+class TestOverheadTable < Minitest::Test
+  def setup
+    @native = Implementation.find(:native, :none)
+    @interpreted = Implementation.find(:pure, :none)
+    @columns = [@native, @interpreted]
+  end
+
+  def row(id, implementation, ips)
+    { 'name' => "#{implementation.backend.label}: #{id}", 'implementation' => implementation.id.to_s,
+      'central_tendency' => ips }
+  end
+
+  def table(results)
+    OverheadTable.new(results: results, implementations: @columns,
+                      without_id: 'error checking off', with_id: 'error checking on').to_markdown
+  end
+
+  def test_reports_one_row_per_implementation
+    results = [row('error checking off', @native, 110.0), row('error checking on', @native, 100.0),
+               row('error checking off', @interpreted, 120.0), row('error checking on', @interpreted, 100.0)]
+
+    markdown = table(results)
+
+    assert_includes markdown, '| Native | 10.0% slower |'
+    assert_includes markdown, '| Pure (no JIT) | 20.0% slower |'
+  end
+
+  def test_skips_an_implementation_missing_either_side
+    results = [row('error checking off', @native, 110.0), row('error checking on', @native, 100.0),
+               row('error checking off', @interpreted, 120.0)]
+
+    markdown = table(results)
+
+    assert_includes markdown, '| Native |'
+    refute_includes markdown, '| Pure (no JIT) |'
+  end
+
+  def test_renders_nothing_when_no_implementation_has_both_sides
+    assert_equal '', table([])
+  end
+end

--- a/test/test_ruby_mode.rb
+++ b/test/test_ruby_mode.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative 'support/fake_vm'
+require_relative '../benchmarks/ruby_mode'
+
+class TestRubyMode < Minitest::Test
+  def test_all_modes_are_distinct_and_named
+    assert_equal %i[none yjit zjit], RubyMode::ALL.map(&:id)
+    assert_equal RubyMode::ALL.size, RubyMode::ALL.map(&:label).uniq.size
+  end
+
+  def test_fetch_accepts_symbol_or_string
+    assert_same RubyMode::ZJIT, RubyMode.fetch(:zjit)
+    assert_same RubyMode::ZJIT, RubyMode.fetch('zjit')
+  end
+
+  def test_fetch_raises_on_unknown_mode
+    error = assert_raises(ArgumentError) { RubyMode.fetch(:jit_that_does_not_exist) }
+
+    assert_includes error.message, 'unknown Ruby mode'
+    assert_includes error.message, 'none, yjit, zjit'
+  end
+
+  def test_each_mode_carries_the_flags_that_launch_it
+    assert_equal ['--disable-yjit'], RubyMode::NO_JIT.cli_flags
+    assert_equal ['--yjit'], RubyMode::YJIT.cli_flags
+    assert_equal ['--zjit'], RubyMode::ZJIT.cli_flags
+  end
+
+  # Detection is exercised against a stand-in VM so all three modes are
+  # covered, not just whichever one this test process happens to be in.
+
+  def test_detects_yjit
+    vm = FakeVM.with(:YJIT)
+
+    assert_same RubyMode::YJIT, RubyMode.active(vm)
+  end
+
+  def test_detects_zjit
+    vm = FakeVM.with(:ZJIT)
+
+    assert_same RubyMode::ZJIT, RubyMode.active(vm)
+  end
+
+  def test_a_vm_with_no_jit_support_at_all_is_no_jit
+    assert_same RubyMode::NO_JIT, RubyMode.active(FakeVM.without_jits)
+  end
+
+  def test_a_jit_that_is_present_but_switched_off_is_no_jit
+    # The exact silent fallback the verification exists to catch: the
+    # constant is there, so a naive `defined?` check would call it enabled.
+    vm = FakeVM.with(:ZJIT, enabled: false)
+
+    assert_same RubyMode::NO_JIT, RubyMode.active(vm)
+  end
+
+  def test_exactly_one_mode_is_active_for_any_vm
+    [FakeVM.with(:YJIT), FakeVM.with(:ZJIT), FakeVM.without_jits, RubyVM].each do |vm|
+      active = RubyMode::ALL.select { |mode| mode.active?(vm) }
+
+      assert_equal 1, active.size, "expected exactly one active mode, got #{active.map(&:id).inspect}"
+    end
+  end
+
+  def test_expected_is_nil_when_unset_so_workers_can_run_standalone
+    assert_nil RubyMode.expected({})
+  end
+
+  def test_expected_reads_the_mode_the_parent_asked_for
+    assert_same RubyMode::ZJIT, RubyMode.expected(RubyMode::ENV_VAR => 'zjit')
+  end
+
+  def test_verify_returns_the_actual_mode_when_it_matches
+    assert_same RubyMode::ZJIT, RubyMode.verify!(actual: RubyMode::ZJIT, expected: RubyMode::ZJIT)
+  end
+
+  def test_verify_skips_the_check_when_nothing_was_expected
+    assert_same RubyMode::NO_JIT, RubyMode.verify!(actual: RubyMode::NO_JIT, expected: nil)
+  end
+
+  def test_verify_raises_when_a_jit_silently_fell_back_to_the_interpreter
+    error = assert_raises(RubyMode::Mismatch) do
+      RubyMode.verify!(actual: RubyMode::NO_JIT, expected: RubyMode::ZJIT, ruby_description: 'ruby 4.0.6 (test)')
+    end
+
+    assert_includes error.message, 'expected to be running under ZJIT'
+    assert_includes error.message, "#{RubyMode::ENV_VAR}=zjit"
+    assert_includes error.message, 'reports no JIT is active'
+    assert_includes error.message, 'ruby 4.0.6 (test)'
+  end
+
+  def test_verify_raises_when_the_other_jit_is_active
+    assert_raises(RubyMode::Mismatch) do
+      RubyMode.verify!(actual: RubyMode::YJIT, expected: RubyMode::ZJIT)
+    end
+  end
+
+  def test_no_jit_reports_no_stats
+    assert_empty RubyMode::NO_JIT.stats(FakeVM.without_jits)
+  end
+
+  def test_yjit_stats_are_read_from_its_own_vocabulary
+    vm = FakeVM.with(:YJIT, stats: { compiled_iseq_count: 412, compilation_failure: 2,
+                                     compile_time_ns: 900, code_region_size: 4096 })
+
+    assert_equal({ 'compiled_iseq_count' => 412, 'failed_iseq_count' => 2,
+                   'compile_time_ns' => 900, 'code_region_bytes' => 4096 },
+                 RubyMode::YJIT.stats(vm))
+  end
+
+  def test_zjit_stats_are_read_from_its_own_vocabulary
+    # ZJIT names the same two concepts differently; consumers see only the
+    # shared keys, so the two JITs stay comparable release over release.
+    vm = FakeVM.with(:ZJIT, stats: { compiled_iseq_count: 208, failed_iseq_count: 3,
+                                     compile_time_ns: 700, code_region_bytes: 2048 })
+
+    assert_equal({ 'compiled_iseq_count' => 208, 'failed_iseq_count' => 3,
+                   'compile_time_ns' => 700, 'code_region_bytes' => 2048 },
+                 RubyMode::ZJIT.stats(vm))
+  end
+
+  def test_jit_enabled_is_false_for_a_constant_the_vm_does_not_define
+    refute RubyMode.jit_enabled?(FakeVM.without_jits, :YJIT)
+  end
+end

--- a/test/test_ruby_mode.rb
+++ b/test/test_ruby_mode.rb
@@ -63,6 +63,21 @@ class TestRubyMode < Minitest::Test
     end
   end
 
+  def test_no_jit_is_available_on_every_ruby
+    assert RubyMode::NO_JIT.available?(FakeVM.without_jits)
+  end
+
+  def test_a_jit_missing_from_the_build_is_unavailable
+    # ZJIT is Ruby 4.0+, so on a 3.x `ruby --zjit` is an error, not a variant.
+    refute RubyMode::ZJIT.available?(FakeVM.with(:YJIT))
+    assert RubyMode::YJIT.available?(FakeVM.with(:YJIT))
+  end
+
+  def test_a_jit_present_but_disabled_is_still_available
+    # Availability is about the build, not the current switch position.
+    assert RubyMode::ZJIT.available?(FakeVM.with(:ZJIT, enabled: false))
+  end
+
   def test_expected_is_nil_when_unset_so_workers_can_run_standalone
     assert_nil RubyMode.expected({})
   end

--- a/test/test_speedup_calculator.rb
+++ b/test/test_speedup_calculator.rb
@@ -2,181 +2,83 @@
 
 require 'test_helper'
 require_relative '../benchmarks/speedup_calculator'
-require 'json'
+require_relative '../benchmarks/implementation'
 
 class TestSpeedupCalculator < Minitest::Test
   def setup
-    @fixtures_dir = File.expand_path('fixtures/benchmarks', __dir__)
+    @native = Implementation.find(:native, :none)
+    @interpreted = Implementation.find(:pure, :none)
+    @yjit = Implementation.find(:pure, :yjit)
+    @zjit = Implementation.find(:pure, :zjit)
   end
 
-  def test_parsing_speedup_calculation
-    # Load real parsing benchmark results
-    data = JSON.parse(File.read(File.join(@fixtures_dir, 'parsing_sample.json')))
-
-    calculator = SpeedupCalculator.new(
-      results: data['results'],
-      test_cases: data['metadata']['test_cases'],
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-      test_case_key: :fixture
-    )
-
-    speedups = calculator.calculate
-
-    # Verify speedup stats structure
-    assert speedups, 'Speedups should not be nil'
-    assert_includes speedups.keys, 'min'
-    assert_includes speedups.keys, 'max'
-    assert_includes speedups.keys, 'avg'
-
-    # Verify speedup values are positive and reasonable
-    assert_operator speedups['min'], :>, 1.0, 'Min speedup should be > 1x'
-    assert_operator speedups['max'], :>=, speedups['min'], 'Max speedup should be >= min'
-    assert_operator speedups['avg'], :>=, speedups['min'], 'Avg speedup should be >= min'
-    assert_operator speedups['avg'], :<=, speedups['max'], 'Avg speedup should be <= max'
-
-    # Verify test cases were annotated with speedups
-    data['metadata']['test_cases'].each do |test_case|
-      assert test_case.key?('speedup'), "Test case '#{test_case['name']}' should have speedup annotated"
-      assert_operator test_case['speedup'], :>, 1.0, "Speedup for '#{test_case['name']}' should be > 1x"
-    end
+  def row(id, implementation, ips)
+    { 'name' => "#{implementation.backend.label}: #{id}", 'implementation' => implementation.id.to_s,
+      'central_tendency' => ips }
   end
 
-  def test_yjit_speedup_calculation
-    # Load real YJIT benchmark results (no test_cases array, just operations)
-    data = JSON.parse(File.read(File.join(@fixtures_dir, 'yjit_sample.json')))
-
-    calculator = SpeedupCalculator.new(
-      results: data['results'],
-      test_cases: data['metadata']['operations'],
-      baseline_matcher: SpeedupCalculator::Matchers.without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.with_yjit,
-      test_case_key: nil # No test_case_key for operations array
-    )
-
-    speedups = calculator.calculate
-
-    # Verify speedup stats
-    assert speedups, 'Speedups should not be nil'
-    assert_operator speedups['min'], :>, 0.0, 'Min speedup should be positive'
-    assert_operator speedups['max'], :>=, speedups['min']
-    assert_operator speedups['avg'], :>=, speedups['min']
-    assert_operator speedups['avg'], :<=, speedups['max']
+  def calculate(results, baseline:, comparison:, test_cases: [])
+    SpeedupCalculator.new(results: results, test_cases: test_cases,
+                          baseline: baseline, comparison: comparison).calculate
   end
 
-  def test_speedup_calculation_with_sample_data
-    # Create minimal sample data for testing pure Ruby vs native
-    results = [
-      { 'name' => 'pure_without_yjit: test1', 'implementation' => 'pure_without_yjit', 'central_tendency' => 100.0 },
-      { 'name' => 'native: test1', 'implementation' => 'native', 'central_tendency' => 500.0 },
-      { 'name' => 'pure_without_yjit: test2', 'implementation' => 'pure_without_yjit', 'central_tendency' => 200.0 },
-      { 'name' => 'native: test2', 'implementation' => 'native', 'central_tendency' => 800.0 }
-    ]
+  def test_reports_the_spread_across_test_cases
+    results = [row('small', @interpreted, 100.0), row('small', @native, 1000.0),
+               row('large', @interpreted, 100.0), row('large', @native, 500.0)]
 
-    test_cases = [
-      { 'name' => 'Test 1', 'key' => 'test1' },
-      { 'name' => 'Test 2', 'key' => 'test2' }
-    ]
+    stats = calculate(results, baseline: @interpreted, comparison: @native)
 
-    calculator = SpeedupCalculator.new(
-      results: results,
-      test_cases: test_cases,
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-      test_case_key: :key
-    )
-
-    speedups = calculator.calculate
-
-    # Verify calculations
-    # test1: 500/100 = 5.0x
-    # test2: 800/200 = 4.0x
-    assert_in_delta(4.0, speedups['min'])
-    assert_in_delta(5.0, speedups['max'])
-    assert_in_delta(4.5, speedups['avg'])
-
-    # Verify test cases were annotated
-    assert_in_delta(5.0, test_cases[0]['speedup'])
-    assert_in_delta(4.0, test_cases[1]['speedup'])
+    assert_in_delta(5.0, stats['min'])
+    assert_in_delta(10.0, stats['max'])
+    assert_in_delta(7.5, stats['avg'])
   end
 
-  def test_speedup_calculation_with_no_matches
-    # No matching baseline/comparison pairs
-    results = [
-      { 'name' => 'pure_without_yjit: test1', 'implementation' => 'pure_without_yjit', 'central_tendency' => 100.0 },
-      { 'name' => 'other_tool: test2', 'implementation' => 'other', 'central_tendency' => 200.0 }
-    ]
+  def test_a_comparison_that_lost_yields_a_ratio_below_one
+    results = [row('small', @yjit, 100.0), row('small', @zjit, 80.0)]
 
-    calculator = SpeedupCalculator.new(
-      results: results,
-      test_cases: [],
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_without_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_native,
-      test_case_key: nil
-    )
-
-    speedups = calculator.calculate
-
-    # Should return nil when no pairs found
-    assert_nil speedups
+    assert_in_delta(0.8, calculate(results, baseline: @yjit, comparison: @zjit)['avg'])
   end
 
-  def test_matchers
-    # Test cataract pure matchers
-    assert SpeedupCalculator::Matchers.cataract_pure_without_yjit.call({ 'implementation' => 'pure_without_yjit' })
-    refute SpeedupCalculator::Matchers.cataract_pure_without_yjit.call({ 'implementation' => 'pure_with_yjit' })
-    refute SpeedupCalculator::Matchers.cataract_pure_without_yjit.call({ 'implementation' => 'native' })
+  def test_annotates_each_test_case_with_its_own_speedup
+    results = [row('small', @interpreted, 100.0), row('small', @native, 1000.0)]
+    test_cases = [{ 'id' => 'small', 'name' => 'Small CSS' }]
 
-    assert SpeedupCalculator::Matchers.cataract_pure_with_yjit.call({ 'implementation' => 'pure_with_yjit' })
-    refute SpeedupCalculator::Matchers.cataract_pure_with_yjit.call({ 'implementation' => 'pure_without_yjit' })
+    calculate(results, test_cases: test_cases, baseline: @interpreted, comparison: @native)
 
-    # Test cataract native matcher
-    assert SpeedupCalculator::Matchers.cataract_native.call({ 'implementation' => 'native' })
-    refute SpeedupCalculator::Matchers.cataract_native.call({ 'implementation' => 'pure_without_yjit' })
-
-    # Test cataract matcher (backwards compatibility - matches native)
-    assert SpeedupCalculator::Matchers.cataract.call({ 'implementation' => 'native' })
-    refute SpeedupCalculator::Matchers.cataract.call({ 'implementation' => 'pure_without_yjit' })
-
-    # Test YJIT matchers
-    assert SpeedupCalculator::Matchers.with_yjit.call({ 'implementation' => 'pure_with_yjit' })
-    refute SpeedupCalculator::Matchers.with_yjit.call({ 'implementation' => 'pure_without_yjit' })
-
-    assert SpeedupCalculator::Matchers.without_yjit.call({ 'implementation' => 'pure_without_yjit' })
-    refute SpeedupCalculator::Matchers.without_yjit.call({ 'implementation' => 'pure_with_yjit' })
-
-    # Test ZJIT matchers
-    assert SpeedupCalculator::Matchers.cataract_pure_with_zjit.call({ 'implementation' => 'pure_with_zjit' })
-    refute SpeedupCalculator::Matchers.cataract_pure_with_zjit.call({ 'implementation' => 'pure_with_yjit' })
-
-    assert SpeedupCalculator::Matchers.with_zjit.call({ 'implementation' => 'pure_with_zjit' })
-    refute SpeedupCalculator::Matchers.with_zjit.call({ 'implementation' => 'pure_with_yjit' })
-    refute SpeedupCalculator::Matchers.with_zjit.call({ 'implementation' => 'pure_without_yjit' })
-
-    # base_implementation (used by cataract_pure/cataract_native/pure_ruby/native_extension)
-    # must strip the ZJIT suffix too, so a ZJIT result is still recognized as "pure"
-    assert SpeedupCalculator::Matchers.cataract_pure.call({ 'implementation' => 'pure_with_zjit' })
-    refute SpeedupCalculator::Matchers.cataract_native.call({ 'implementation' => 'pure_with_zjit' })
+    assert_in_delta(10.0, test_cases.first['speedup'])
   end
 
-  def test_zjit_vs_yjit_speedup_calculation
-    results = [
-      { 'name' => 'pure_with_yjit: test1', 'implementation' => 'pure_with_yjit', 'central_tendency' => 100.0 },
-      { 'name' => 'pure_with_zjit: test1', 'implementation' => 'pure_with_zjit', 'central_tendency' => 80.0 }
-    ]
+  def test_skips_test_cases_only_one_side_measured
+    results = [row('small', @interpreted, 100.0), row('small', @native, 1000.0),
+               row('large', @interpreted, 100.0)]
 
-    calculator = SpeedupCalculator.new(
-      results: results,
-      test_cases: [],
-      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_with_yjit,
-      comparison_matcher: SpeedupCalculator::Matchers.cataract_pure_with_zjit,
-      test_case_key: nil
-    )
+    assert_in_delta(10.0, calculate(results, baseline: @interpreted, comparison: @native)['avg'])
+  end
 
-    speedups = calculator.calculate
+  def test_returns_nil_when_the_two_share_no_test_case
+    results = [row('small', @interpreted, 100.0), row('large', @native, 1000.0)]
 
-    # ZJIT (80) is slower than YJIT (100) here - speedup should reflect that as < 1
-    assert speedups, 'Speedups should not be nil'
-    assert_in_delta(0.8, speedups['avg'])
+    assert_nil calculate(results, baseline: @interpreted, comparison: @native)
+  end
+
+  def test_returns_nil_when_there_are_no_results
+    assert_nil calculate([], baseline: @interpreted, comparison: @native)
+  end
+
+  def test_the_two_jits_are_told_apart_by_implementation_not_by_report_name
+    # Both JIT rows carry the same report label; only the stamped
+    # implementation distinguishes them.
+    results = [row('small', @yjit, 214.8), row('small', @zjit, 127.3)]
+
+    assert_in_delta(0.59, calculate(results, baseline: @yjit, comparison: @zjit)['avg'], 0.01)
+    assert_in_delta(1.69, calculate(results, baseline: @zjit, comparison: @yjit)['avg'], 0.01)
+  end
+
+  def test_a_test_case_id_containing_a_colon_is_split_at_the_last_one
+    results = [{ 'name' => 'cataract pure: a: b', 'implementation' => @interpreted.id.to_s,
+                 'central_tendency' => 100.0 },
+               { 'name' => 'cataract: a: b', 'implementation' => @native.id.to_s, 'central_tendency' => 200.0 }]
+
+    assert_in_delta(2.0, calculate(results, baseline: @interpreted, comparison: @native)['avg'])
   end
 end

--- a/test/test_speedup_calculator.rb
+++ b/test/test_speedup_calculator.rb
@@ -144,5 +144,39 @@ class TestSpeedupCalculator < Minitest::Test
 
     assert SpeedupCalculator::Matchers.without_yjit.call({ 'implementation' => 'pure_without_yjit' })
     refute SpeedupCalculator::Matchers.without_yjit.call({ 'implementation' => 'pure_with_yjit' })
+
+    # Test ZJIT matchers
+    assert SpeedupCalculator::Matchers.cataract_pure_with_zjit.call({ 'implementation' => 'pure_with_zjit' })
+    refute SpeedupCalculator::Matchers.cataract_pure_with_zjit.call({ 'implementation' => 'pure_with_yjit' })
+
+    assert SpeedupCalculator::Matchers.with_zjit.call({ 'implementation' => 'pure_with_zjit' })
+    refute SpeedupCalculator::Matchers.with_zjit.call({ 'implementation' => 'pure_with_yjit' })
+    refute SpeedupCalculator::Matchers.with_zjit.call({ 'implementation' => 'pure_without_yjit' })
+
+    # base_implementation (used by cataract_pure/cataract_native/pure_ruby/native_extension)
+    # must strip the ZJIT suffix too, so a ZJIT result is still recognized as "pure"
+    assert SpeedupCalculator::Matchers.cataract_pure.call({ 'implementation' => 'pure_with_zjit' })
+    refute SpeedupCalculator::Matchers.cataract_native.call({ 'implementation' => 'pure_with_zjit' })
+  end
+
+  def test_zjit_vs_yjit_speedup_calculation
+    results = [
+      { 'name' => 'pure_with_yjit: test1', 'implementation' => 'pure_with_yjit', 'central_tendency' => 100.0 },
+      { 'name' => 'pure_with_zjit: test1', 'implementation' => 'pure_with_zjit', 'central_tendency' => 80.0 }
+    ]
+
+    calculator = SpeedupCalculator.new(
+      results: results,
+      test_cases: [],
+      baseline_matcher: SpeedupCalculator::Matchers.cataract_pure_with_yjit,
+      comparison_matcher: SpeedupCalculator::Matchers.cataract_pure_with_zjit,
+      test_case_key: nil
+    )
+
+    speedups = calculator.calculate
+
+    # ZJIT (80) is slower than YJIT (100) here - speedup should reflect that as < 1
+    assert speedups, 'Speedups should not be nil'
+    assert_in_delta(0.8, speedups['avg'])
   end
 end

--- a/test/test_worker_helpers.rb
+++ b/test/test_worker_helpers.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require_relative '../benchmarks/worker_helpers'
+
+class TestWorkerHelpers < Minitest::Test
+  class DummyTestModule
+    def self.yjit_applicable?(base_impl)
+      base_impl != :native
+    end
+  end
+
+  class DummyWorker
+    include WorkerHelpers
+
+    attr_accessor :impl_type
+
+    public :determine_impl_type, :verify_jit_mode!
+  end
+
+  def setup
+    @worker = DummyWorker.new
+  end
+
+  def teardown
+    ENV.delete('CATARACT_BENCH_JIT')
+  end
+
+  def test_native_is_never_checked_regardless_of_env
+    ENV['CATARACT_BENCH_JIT'] = 'zjit' # deliberately mismatched - native ignores it
+
+    assert_equal :native, @worker.determine_impl_type(:native, DummyTestModule)
+  end
+
+  def test_verify_jit_mode_skips_when_no_expectation_set
+    ENV.delete('CATARACT_BENCH_JIT')
+    @worker.verify_jit_mode!(:none) # standalone/debug run - no error
+  end
+
+  def test_verify_jit_mode_passes_when_actual_matches_expected
+    ENV['CATARACT_BENCH_JIT'] = 'zjit'
+    @worker.verify_jit_mode!(:zjit) # no error
+  end
+
+  def test_verify_jit_mode_raises_when_actual_falls_back_to_none
+    # This is the exact failure this check exists to catch: we asked for
+    # ZJIT but the process silently fell back to the plain interpreter
+    # (e.g. a Ruby build without ZJIT support ignoring --zjit).
+    ENV['CATARACT_BENCH_JIT'] = 'zjit'
+
+    error = assert_raises(RuntimeError) { @worker.verify_jit_mode!(:none) }
+    expected_message = 'JIT mode mismatch: expected CATARACT_BENCH_JIT=zjit but RubyVM reports ' \
+                       "none is active (#{RUBY_DESCRIPTION}) - was this Ruby built with YJIT/ZJIT support?"
+
+    assert_equal expected_message, error.message
+  end
+
+  def test_verify_jit_mode_raises_when_actual_is_the_other_jit
+    ENV['CATARACT_BENCH_JIT'] = 'yjit'
+    assert_raises(RuntimeError) { @worker.verify_jit_mode!(:zjit) }
+  end
+end

--- a/test/test_worker_helpers.rb
+++ b/test/test_worker_helpers.rb
@@ -4,59 +4,37 @@ require 'test_helper'
 require_relative '../benchmarks/worker_helpers'
 
 class TestWorkerHelpers < Minitest::Test
-  class DummyTestModule
-    def self.yjit_applicable?(base_impl)
-      base_impl != :native
+  class Worker
+    include WorkerHelpers
+
+    def self.benchmark_name
+      'serialization'
+    end
+
+    def initialize(implementation)
+      @implementation = implementation
     end
   end
 
-  class DummyWorker
-    include WorkerHelpers
-
-    attr_accessor :impl_type
-
-    public :determine_impl_type, :verify_jit_mode!
-  end
-
   def setup
-    @worker = DummyWorker.new
+    @zjit = Worker.new(Implementation.find(:pure, :zjit))
+    @native = Worker.new(Implementation.find(:native, :none))
   end
 
-  def teardown
-    ENV.delete('CATARACT_BENCH_JIT')
+  def test_result_filename_is_scoped_to_the_variant
+    assert_equal 'serialization_pure_zjit', @zjit.benchmark_name
+    assert_equal 'serialization_native_none', @native.benchmark_name
   end
 
-  def test_native_is_never_checked_regardless_of_env
-    ENV['CATARACT_BENCH_JIT'] = 'zjit' # deliberately mismatched - native ignores it
-
-    assert_equal :native, @worker.determine_impl_type(:native, DummyTestModule)
+  def test_report_names_follow_the_label_colon_id_convention
+    assert_equal 'cataract pure: bootstrap_compact', @zjit.result_name('bootstrap_compact')
+    assert_equal 'cataract: bootstrap_compact', @native.result_name('bootstrap_compact')
   end
 
-  def test_verify_jit_mode_skips_when_no_expectation_set
-    ENV.delete('CATARACT_BENCH_JIT')
-    @worker.verify_jit_mode!(:none) # standalone/debug run - no error
-  end
+  def test_report_names_omit_the_jit_because_results_carry_it_as_a_field
+    id = 'selector lists'
 
-  def test_verify_jit_mode_passes_when_actual_matches_expected
-    ENV['CATARACT_BENCH_JIT'] = 'zjit'
-    @worker.verify_jit_mode!(:zjit) # no error
-  end
-
-  def test_verify_jit_mode_raises_when_actual_falls_back_to_none
-    # This is the exact failure this check exists to catch: we asked for
-    # ZJIT but the process silently fell back to the plain interpreter
-    # (e.g. a Ruby build without ZJIT support ignoring --zjit).
-    ENV['CATARACT_BENCH_JIT'] = 'zjit'
-
-    error = assert_raises(RuntimeError) { @worker.verify_jit_mode!(:none) }
-    expected_message = 'JIT mode mismatch: expected CATARACT_BENCH_JIT=zjit but RubyVM reports ' \
-                       "none is active (#{RUBY_DESCRIPTION}) - was this Ruby built with YJIT/ZJIT support?"
-
-    assert_equal expected_message, error.message
-  end
-
-  def test_verify_jit_mode_raises_when_actual_is_the_other_jit
-    ENV['CATARACT_BENCH_JIT'] = 'yjit'
-    assert_raises(RuntimeError) { @worker.verify_jit_mode!(:zjit) }
+    assert_equal Worker.new(Implementation.find(:pure, :yjit)).result_name(id),
+                 Worker.new(Implementation.find(:pure, :zjit)).result_name(id)
   end
 end


### PR DESCRIPTION
Each pure-Ruby benchmark now runs a third subprocess variant under --zjit in addition to the existing no-JIT and --yjit runs, so BENCHMARKS.md reports native, interpreter, YJIT, and ZJIT side by side with a ZJIT-vs-YJIT speedup row as the headline comparison.

Each worker subprocess is told which JIT mode it's expected to be running under via CATARACT_BENCH_JIT and asserts that RubyVM actually reports that mode before any benchmarking starts, so a Ruby build that silently can't honor --yjit/--zjit (or an inherited environment variable overriding the intended flag) fails loudly instead of quietly measuring the wrong thing under the wrong label.

Also fixes format_speedup, which always labeled a comparison "faster" regardless of the ratio - misleading now that ZJIT vs YJIT can legitimately come out slower.