### PR TITLE
Load the networking stack only when an import needs it

### DIFF
--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -2,7 +2,7 @@ name: CI - WebAssembly
 
 # Manual only. This pulls a ~40MB prebuilt Ruby and a wasm runtime, covers the
 # pure Ruby backend alone, and answers a question that changes rarely: does the
-# library still work where there are no sockets and no C extension?
+# library still work with no socket extension and no C extension?
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -1,0 +1,52 @@
+name: CI - WebAssembly
+
+# Manual only. This pulls a ~40MB prebuilt Ruby and a wasm runtime, covers the
+# pure Ruby backend alone, and answers a question that changes rarely: does the
+# library still work where there are no sockets and no C extension?
+on:
+  workflow_dispatch:
+    inputs:
+      ruby:
+        description: Which ruby.wasm build to test against
+        required: true
+        default: '4.0'
+        type: choice
+        options: ['3.3', '3.4', '4.0', 'head']
+
+jobs:
+  wasi:
+    name: wasm32-unknown-wasip1 (ruby ${{ inputs.ruby }})
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install wasmtime
+      uses: bytecodealliance/actions/wasmtime/setup@v1
+
+    - name: Download prebuilt ruby.wasm
+      run: |
+        set -euo pipefail
+        build="ruby-${{ inputs.ruby }}-wasm32-unknown-wasip1-full"
+        curl -fsSL -o ruby-wasm.tar.gz \
+          "https://github.com/ruby/ruby.wasm/releases/latest/download/${build}.tar.gz"
+        tar xzf ruby-wasm.tar.gz
+        echo "RUBY_WASM_ROOT=${PWD}/${build}" >> "$GITHUB_ENV"
+
+    - name: Show the wasm Ruby it will run
+      run: |
+        wasmtime run --dir "${RUBY_WASM_ROOT}/usr::/usr" \
+          "${RUBY_WASM_ROOT}/usr/local/bin/ruby" -- --version
+
+    # CATARACT_PURE is set because the C extension can't be cross-compiled to
+    # wasm; the smoke script asserts the pure backend actually loaded rather
+    # than trusting the variable. /usr carries the wasm Ruby's own stdlib,
+    # /app is this checkout - WASI grants no filesystem access without these.
+    - name: Run the WASI smoke checks
+      run: |
+        wasmtime run \
+          --env CATARACT_PURE=1 \
+          --dir "${RUBY_WASM_ROOT}/usr::/usr" \
+          --dir ".::/app" \
+          "${RUBY_WASM_ROOT}/usr/local/bin/ruby" \
+          -- -I/app/lib /app/test/wasm/smoke.rb

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -36,12 +36,16 @@ jobs:
     - name: Show the wasm Ruby it will run
       run: |
         wasmtime run --dir "${RUBY_WASM_ROOT}/usr::/usr" \
-          "${RUBY_WASM_ROOT}/usr/local/bin/ruby" -- --version
+          "${RUBY_WASM_ROOT}/usr/local/bin/ruby" --version
 
     # CATARACT_PURE is set because the C extension can't be cross-compiled to
     # wasm; the smoke script asserts the pure backend actually loaded rather
     # than trusting the variable. /usr carries the wasm Ruby's own stdlib,
     # /app is this checkout - WASI grants no filesystem access without these.
+    #
+    # No `--` before the Ruby arguments: wasmtime takes the first argument
+    # after it as argv[0], leaving Ruby to treat its own first flag as a
+    # script name. test/wasm/Dockerfile runs this same command locally.
     - name: Run the WASI smoke checks
       run: |
         wasmtime run \
@@ -49,4 +53,4 @@ jobs:
           --dir "${RUBY_WASM_ROOT}/usr::/usr" \
           --dir ".::/app" \
           "${RUBY_WASM_ROOT}/usr/local/bin/ruby" \
-          -- -I/app/lib /app/test/wasm/smoke.rb
+          -I/app/lib /app/test/wasm/smoke.rb

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -12,7 +12,7 @@ Performance comparison between Cataract's C extension and pure Ruby implementati
 - **CPU**: Apple M1 Pro
 - **Memory**: 32GB
 - **OS**: macOS 26.3.1
-- **Generated**: 2026-07-30T21:02:54-05:00
+- **Generated**: 2026-07-31T17:03:14-05:00
 
 ## CSS Parsing
 
@@ -20,20 +20,20 @@ Time to parse CSS into internal data structures
 
 | Test Case | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
 | --------- | ------ | ------------- | ----------- | ----------- |
-| Small CSS (64 lines, 1.0KB) | 31.29K i/s | 3.3K i/s | 13.76K i/s | 7.53K i/s |
-| Medium CSS with @media (139 lines, 1.6KB) | 28.46K i/s | 2.06K i/s | 8.88K i/s | 4.78K i/s |
-| Selector lists (3500 lines, 62.5KB, 500 lists) | 369.3 i/s | 57.5 i/s | 216.9 i/s | 125.5 i/s |
+| Small CSS (64 lines, 1.0KB) | 31.49K i/s | 3.4K i/s | 13.96K i/s | 7.65K i/s |
+| Medium CSS with @media (139 lines, 1.6KB) | 28.99K i/s | 2.14K i/s | 9.09K i/s | 4.9K i/s |
+| Selector lists (3500 lines, 62.5KB, 500 lists) | 385.9 i/s | 57.9 i/s | 219.4 i/s | 129.1 i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no JIT) | 11.42x faster (avg) |
-| Native vs Pure (YJIT) | 2.74x faster (avg) |
-| Native vs Pure (ZJIT) | 4.92x faster (avg) |
-| YJIT impact on Pure Ruby | 4.15x faster (avg) |
+| Native vs Pure (no JIT) | 11.62x faster (avg) |
+| Native vs Pure (YJIT) | 2.78x faster (avg) |
+| Native vs Pure (ZJIT) | 5.02x faster (avg) |
+| YJIT impact on Pure Ruby | 4.16x faster (avg) |
 | ZJIT impact on Pure Ruby | 2.31x faster (avg) |
-| ZJIT vs YJIT | 1.79x slower (avg) |
+| ZJIT vs YJIT | 1.82x slower (avg) |
 
 ### Parse Error Checking Overhead
 
@@ -41,17 +41,17 @@ Parse error detection can be enabled with `raise_parse_errors: true`. This compa
 
 | Configuration | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
 | ------------- | ------ | ------------- | ----------- | ----------- |
-| Medium CSS (139 lines) - no error checking | 27.71K i/s | 2.09K i/s | 8.62K i/s | 4.84K i/s |
-| Medium CSS (139 lines) - with error checking | 27.36K i/s | 1.92K i/s | 7.97K i/s | 4.55K i/s |
+| Medium CSS (139 lines) - no error checking | 29.28K i/s | 2.13K i/s | 9.06K i/s | 4.9K i/s |
+| Medium CSS (139 lines) - with error checking | 28.99K i/s | 1.96K i/s | 8.15K i/s | 4.62K i/s |
 
 **Overhead Analysis:**
 
 | Implementation | Overhead |
 |----------------|----------|
-| Native | 1.3% slower |
-| Pure (no JIT) | 9.0% slower |
-| Pure (YJIT) | 8.2% slower |
-| Pure (ZJIT) | 6.3% slower |
+| Native | 1.0% slower |
+| Pure (no JIT) | 8.6% slower |
+| Pure (YJIT) | 11.2% slower |
+| Pure (ZJIT) | 6.2% slower |
 
 ---
 
@@ -61,22 +61,22 @@ Time to convert parsed CSS back to string format
 
 | Test Case | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
 | --------- | ------ | ------------- | ----------- | ----------- |
-| to_s (Bootstrap - 191KB) | 984.2 i/s | 301.6 i/s | 484.0 i/s | 338.1 i/s |
-| to_s (Compact utilities - 2.9KB) | 50.4K i/s | 11.02K i/s | 18.96K i/s | 10.9K i/s |
-| to_formatted_s (Nested CSS - 1.3KB) | 151.49K i/s | 54.68K i/s | 87.22K i/s | 64.4K i/s |
-| to_s with selector_lists (3.4KB) | 14.99K i/s | 6.72K i/s | 10.69K i/s | 7.87K i/s |
-| Media filtering (Bootstrap print only) | 1.1K i/s | 464.3 i/s | 694.0 i/s | 528.0 i/s |
+| to_s (Bootstrap - 191KB) | 1.0K i/s | 302.1 i/s | 478.6 i/s | 345.8 i/s |
+| to_s (Compact utilities - 2.9KB) | 51.64K i/s | 11.23K i/s | 19.41K i/s | 11.22K i/s |
+| to_formatted_s (Nested CSS - 1.3KB) | 153.95K i/s | 55.34K i/s | 90.08K i/s | 64.85K i/s |
+| to_s with selector_lists (3.4KB) | 15.33K i/s | 6.78K i/s | 10.84K i/s | 7.93K i/s |
+| Media filtering (Bootstrap print only) | 1.12K i/s | 472.4 i/s | 702.9 i/s | 546.9 i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no JIT) | 3.04x faster (avg) |
-| Native vs Pure (YJIT) | 1.88x faster (avg) |
+| Native vs Pure (no JIT) | 3.07x faster (avg) |
+| Native vs Pure (YJIT) | 1.89x faster (avg) |
 | Native vs Pure (ZJIT) | 2.77x faster (avg) |
-| YJIT impact on Pure Ruby | 1.6x faster (avg) |
-| ZJIT impact on Pure Ruby | 1.12x faster (avg) |
-| ZJIT vs YJIT | 1.43x slower (avg) |
+| YJIT impact on Pure Ruby | 1.61x faster (avg) |
+| ZJIT impact on Pure Ruby | 1.13x faster (avg) |
+| ZJIT vs YJIT | 1.41x slower (avg) |
 
 ---
 
@@ -86,23 +86,23 @@ Time to calculate CSS selector specificity values
 
 | Test Case | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
 | --------- | ------ | ------------- | ----------- | ----------- |
-| Simple Selectors | 1.02M i/s | 413.96K i/s | 1.43M i/s | 749.57K i/s |
-| Compound Selectors | 997.92K i/s | 183.13K i/s | 498.8K i/s | 404.43K i/s |
-| Combinators | 757.46K i/s | 136.54K i/s | 267.01K i/s | 260.74K i/s |
-| Pseudo-classes & Pseudo-elements | 757.92K i/s | 113.58K i/s | 224.99K i/s | 209.63K i/s |
-| :not() Pseudo-class (CSS3) | 883.15K i/s | 110.53K i/s | 237.8K i/s | 189.57K i/s |
-| Complex Real-world Selectors | 913.36K i/s | 55.32K i/s | 120.83K i/s | 116.13K i/s |
+| Simple Selectors | 1.04M i/s | 419.22K i/s | 1.44M i/s | 759.22K i/s |
+| Compound Selectors | 1.02M i/s | 185.49K i/s | 504.13K i/s | 409.23K i/s |
+| Combinators | 761.42K i/s | 137.7K i/s | 271.55K i/s | 260.99K i/s |
+| Pseudo-classes & Pseudo-elements | 762.04K i/s | 115.91K i/s | 230.05K i/s | 211.96K i/s |
+| :not() Pseudo-class (CSS3) | 896.14K i/s | 111.68K i/s | 246.68K i/s | 191.71K i/s |
+| Complex Real-world Selectors | 926.9K i/s | 55.9K i/s | 122.65K i/s | 116.52K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no JIT) | 7.44x faster (avg) |
-| Native vs Pure (YJIT) | 3.37x faster (avg) |
-| Native vs Pure (ZJIT) | 3.81x faster (avg) |
-| YJIT impact on Pure Ruby | 2.41x faster (avg) |
-| ZJIT impact on Pure Ruby | 1.93x faster (avg) |
-| ZJIT vs YJIT | 1.2x slower (avg) |
+| Native vs Pure (no JIT) | 7.45x faster (avg) |
+| Native vs Pure (YJIT) | 3.34x faster (avg) |
+| Native vs Pure (ZJIT) | 3.83x faster (avg) |
+| YJIT impact on Pure Ruby | 2.42x faster (avg) |
+| ZJIT impact on Pure Ruby | 1.92x faster (avg) |
+| ZJIT vs YJIT | 1.22x slower (avg) |
 
 ---
 
@@ -112,23 +112,23 @@ Time to flatten multiple CSS rule sets with same selector
 
 | Test Case | Native | Pure (no JIT) | Pure (YJIT) | Pure (ZJIT) |
 | --------- | ------ | ------------- | ----------- | ----------- |
-| No shorthand properties (large) | 13.28K i/s | 2.85K i/s | 5.37K i/s | 3.44K i/s |
-| Simple properties | 138.9K i/s | 54.39K i/s | 84.42K i/s | 65.18K i/s |
-| Cascade with specificity | 168.14K i/s | 52.88K i/s | 86.97K i/s | 65.61K i/s |
-| Important declarations | 167.4K i/s | 53.61K i/s | 87.29K i/s | 65.6K i/s |
-| Shorthand expansion | 132.57K i/s | 46.27K i/s | 78.43K i/s | 58.86K i/s |
-| Complex flattening | 32.18K i/s | 11.32K i/s | 17.41K i/s | 14.11K i/s |
+| No shorthand properties (large) | 12.59K i/s | 2.89K i/s | 5.49K i/s | 3.51K i/s |
+| Simple properties | 133.58K i/s | 54.85K i/s | 85.53K i/s | 67.83K i/s |
+| Cascade with specificity | 163.14K i/s | 54.45K i/s | 87.66K i/s | 68.03K i/s |
+| Important declarations | 163.15K i/s | 54.55K i/s | 87.65K i/s | 68.08K i/s |
+| Shorthand expansion | 128.2K i/s | 48.71K i/s | 79.16K i/s | 61.07K i/s |
+| Complex flattening | 31.25K i/s | 11.65K i/s | 17.15K i/s | 14.43K i/s |
 
 ### Speedups
 
 | Comparison | Speedup |
 |------------|---------|
-| Native vs Pure (no JIT) | 3.2x faster (avg) |
-| Native vs Pure (YJIT) | 1.92x faster (avg) |
-| Native vs Pure (ZJIT) | 2.61x faster (avg) |
-| YJIT impact on Pure Ruby | 1.66x faster (avg) |
-| ZJIT impact on Pure Ruby | 1.23x faster (avg) |
-| ZJIT vs YJIT | 1.33x slower (avg) |
+| Native vs Pure (no JIT) | 3.02x faster (avg) |
+| Native vs Pure (YJIT) | 1.84x faster (avg) |
+| Native vs Pure (ZJIT) | 2.44x faster (avg) |
+| YJIT impact on Pure Ruby | 1.63x faster (avg) |
+| ZJIT impact on Pure Ruby | 1.24x faster (avg) |
+| ZJIT vs YJIT | 1.3x slower (avg) |
 
 ---
 

--- a/benchmarks/benchmark_harness.rb
+++ b/benchmarks/benchmark_harness.rb
@@ -4,6 +4,7 @@ require 'benchmark/ips'
 require 'json'
 require 'fileutils'
 require 'open3'
+require 'time' # Time#iso8601 - core only carries it from Ruby 4.0 on
 require_relative 'system_metadata'
 require_relative 'speedup_calculator'
 require_relative 'implementation'
@@ -117,8 +118,10 @@ class BenchmarkHarness
       instance.call
       finalize(instance) unless skip_finalize
     rescue StandardError => e
-      puts "❌ Benchmark failed: #{e.message}"
-      puts e.backtrace.first(5).join("\n")
+      # stderr, not stdout: a parent process collects this to explain why a
+      # worker died, and stdout is where benchmark-ips results go.
+      warn "❌ Benchmark failed: #{e.message}"
+      warn e.backtrace.first(5).join("\n")
       exit 1
     end
 
@@ -273,8 +276,8 @@ class BenchmarkHarness
       # results location survives the process boundary.
       env = implementation.env.merge(results.env)
       command = implementation.ruby_command(worker_script)
-      _, stderr, status = run_subprocess(command, env: env)
-      raise variant_failure(implementation, command, env, stderr, status) unless status.success?
+      stdout, stderr, status = run_subprocess(command, env: env)
+      raise variant_failure(implementation, command_line(command, env), stdout, stderr, status) unless status.success?
 
       puts
       puts
@@ -295,22 +298,25 @@ class BenchmarkHarness
   # extension arrives as a signal with no Ruby backtrace anywhere. The command
   # and the JIT/backend variables are included because the variant is only
   # reproducible with them.
-  def variant_failure(implementation, command, env, stderr, status)
+  def variant_failure(implementation, command_line, stdout, stderr, status)
     cause = if status.signaled?
               "killed by SIG#{Signal.signame(status.termsig) || status.termsig}"
             else
               "exited #{status.exitstatus}"
             end
 
-    selected = env.compact.map { |name, value| "#{name}=#{value}" }.join(' ')
-    output = stderr.strip.empty? ? '  (worker wrote nothing to stderr)' : indent(stderr.lines.last(20))
+    # Falls back to stdout because a worker's last words don't always land on
+    # stderr, and an empty report is the one thing worse than a wrong guess.
+    stream, output = stderr.strip.empty? ? ['stdout (stderr was empty)', stdout] : ['stderr', stderr]
+    tail = output.strip.empty? ? '    (worker produced no output)' : indent(output.lines.last(20))
 
-    [
-      "#{implementation} benchmark failed - #{cause}",
-      "  command: #{selected} #{command.join(' ')}",
-      '  stderr:',
-      output
-    ].join("\n")
+    ["#{implementation} benchmark failed - #{cause}", "  command: #{command_line}", "  #{stream}:", tail].join("\n")
+  end
+
+  # The variant's selecting variables belong with the command; without them it
+  # reproduces a different run.
+  def command_line(command, env)
+    [*env.compact.map { |name, value| "#{name}=#{value}" }, *command].join(' ')
   end
 
   def indent(lines)

--- a/benchmarks/benchmark_harness.rb
+++ b/benchmarks/benchmark_harness.rb
@@ -272,8 +272,9 @@ class BenchmarkHarness
       # Workers write into the same directory as their parent, so a redirected
       # results location survives the process boundary.
       env = implementation.env.merge(results.env)
-      _, status = run_subprocess(implementation.ruby_command(worker_script), env: env)
-      raise "#{implementation} benchmark failed" unless status.success?
+      command = implementation.ruby_command(worker_script)
+      _, stderr, status = run_subprocess(command, env: env)
+      raise variant_failure(implementation, command, env, stderr, status) unless status.success?
 
       puts
       puts
@@ -288,13 +289,43 @@ class BenchmarkHarness
     "#{self.class.benchmark_name}_*.json"
   end
 
+  # Describes how a variant died, not just that it did.
+  #
+  # A worker can raise, exit non-zero, or be killed outright - a crash in the C
+  # extension arrives as a signal with no Ruby backtrace anywhere. The command
+  # and the JIT/backend variables are included because the variant is only
+  # reproducible with them.
+  def variant_failure(implementation, command, env, stderr, status)
+    cause = if status.signaled?
+              "killed by SIG#{Signal.signame(status.termsig) || status.termsig}"
+            else
+              "exited #{status.exitstatus}"
+            end
+
+    selected = env.compact.map { |name, value| "#{name}=#{value}" }.join(' ')
+    output = stderr.strip.empty? ? '  (worker wrote nothing to stderr)' : indent(stderr.lines.last(20))
+
+    [
+      "#{implementation} benchmark failed - #{cause}",
+      "  command: #{selected} #{command.join(' ')}",
+      '  stderr:',
+      output
+    ].join("\n")
+  end
+
+  def indent(lines)
+    lines.map { |line| "    #{line}" }.join
+  end
+
   def run_subprocess(command, env: {})
     stdout_lines = []
+    stderr_lines = []
 
     Open3.popen3(env, *command) do |stdin, stdout, stderr, wait_thr|
       stdin.close
 
-      # Stream both streams as they arrive so a long benchmark isn't silent
+      # Stream both streams as they arrive so a long benchmark isn't silent,
+      # and keep stderr so a failure can be explained after the fact.
       readers = [
         Thread.new do
           stdout.each_line do |line|
@@ -302,11 +333,16 @@ class BenchmarkHarness
             stdout_lines << line
           end
         end,
-        Thread.new { stderr.each_line { |line| warn "⚠️  #{line}" } }
+        Thread.new do
+          stderr.each_line do |line|
+            warn "⚠️  #{line}"
+            stderr_lines << line
+          end
+        end
       ]
       readers.each(&:join)
 
-      return [stdout_lines.join, wait_thr.value]
+      return [stdout_lines.join, stderr_lines.join, wait_thr.value]
     end
   end
 

--- a/benchmarks/benchmark_runner.rb
+++ b/benchmarks/benchmark_runner.rb
@@ -3,6 +3,7 @@
 require 'benchmark/ips'
 require 'json'
 require 'fileutils'
+require 'time' # Time#iso8601 - core only carries it from Ruby 4.0 on
 
 # Unified benchmark runner that outputs both human-readable console output
 # and structured JSON for documentation generation.

--- a/benchmarks/system_metadata.rb
+++ b/benchmarks/system_metadata.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'fileutils'
+require 'time' # Time#iso8601 - core only carries it from Ruby 4.0 on
 require_relative 'results_directory'
 
 # Collects system metadata for benchmark runs

--- a/lib/cataract/import_resolver.rb
+++ b/lib/cataract/import_resolver.rb
@@ -2,12 +2,6 @@
 
 require 'uri'
 
-# open-uri and ssrf_filter load in DefaultFetcher#fetch_http, not here: they
-# pull in net/http and resolv, which need the socket extension. Everything else
-# in this file - option validation, URL normalization, file:// fetching, and
-# any caller-supplied fetcher - works without them, and so works on hosts that
-# have no sockets. `uri` is pure Ruby.
-
 module Cataract
   # Error raised during import resolution
   class ImportError < Error; end

--- a/lib/cataract/import_resolver.rb
+++ b/lib/cataract/import_resolver.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 require 'uri'
-require 'open-uri'
-require 'ssrf_filter'
+
+# open-uri and ssrf_filter load in DefaultFetcher#fetch_http, not here: they
+# pull in net/http and resolv, which need the socket extension. Everything else
+# in this file - option validation, URL normalization, file:// fetching, and
+# any caller-supplied fetcher - works without them, and so works on hosts that
+# have no sockets. `uri` is pure Ruby.
 
 module Cataract
   # Error raised during import resolution
@@ -29,31 +33,42 @@ module Cataract
           File.read(uri.path)
         when 'http', 'https'
           # Fetch from network
-          fetch_http(uri, options)
+          fetch_http(uri, options, url)
         else
           raise ImportError, "Unsupported scheme: #{uri.scheme}"
         end
       rescue Errno::ENOENT
         raise ImportError, "Import file not found: #{url}"
-      rescue OpenURI::HTTPError => e
-        raise ImportError, "HTTP error fetching import: #{url} (#{e.message})"
-      rescue SocketError => e
-        raise ImportError, "Network error fetching import: #{url} (#{e.message})"
-      rescue SsrfFilter::Error => e
-        raise ImportError, "Import blocked by SSRF protection: #{url} (#{e.message})"
+      rescue ImportError
+        raise # already specific; re-wrapping nests it inside a vaguer message
       rescue StandardError => e
         raise ImportError, "Error fetching import: #{url} (#{e.class}: #{e.message})"
       end
 
       private
 
-      # Fetch content via HTTP/HTTPS
-      def fetch_http(uri, options)
+      # Fetch content via HTTP/HTTPS.
+      #
+      # Loads the HTTP libraries and translates their errors here, so that no
+      # rescue above this point names a constant that may not be loadable.
+      #
+      # @param url [String] the URL as written; `uri` may have been resolved
+      #   against a base and no longer match what the stylesheet requested
+      def fetch_http(uri, options, url)
+        require 'open-uri'
+        require 'ssrf_filter'
+
         if options[:allow_local_network]
           fetch_http_unfiltered(uri, options)
         else
           fetch_http_ssrf_safe(uri, options)
         end
+      rescue OpenURI::HTTPError => e
+        raise ImportError, "HTTP error fetching import: #{url} (#{e.message})"
+      rescue SocketError => e
+        raise ImportError, "Network error fetching import: #{url} (#{e.message})"
+      rescue SsrfFilter::Error => e
+        raise ImportError, "Import blocked by SSRF protection: #{url} (#{e.message})"
       end
 
       # Plain open-uri fetch, no SSRF protection - only reachable when the

--- a/lib/cataract/native.rb
+++ b/lib/cataract/native.rb
@@ -28,6 +28,3 @@ require_relative 'native_extension'
 require_relative 'stylesheet_scope'
 require_relative 'stylesheet'
 require_relative 'declarations'
-
-# import_resolver is required on entry to Stylesheet#load_uri and
-# #resolve_imports rather than here - see the note in pure.rb.

--- a/lib/cataract/native.rb
+++ b/lib/cataract/native.rb
@@ -28,4 +28,6 @@ require_relative 'native_extension'
 require_relative 'stylesheet_scope'
 require_relative 'stylesheet'
 require_relative 'declarations'
-require_relative 'import_resolver'
+
+# import_resolver is required on entry to Stylesheet#load_uri and
+# #resolve_imports rather than here - see the note in pure.rb.

--- a/lib/cataract/pure.rb
+++ b/lib/cataract/pure.rb
@@ -42,7 +42,10 @@ require_relative 'import_statement'
 require_relative 'stylesheet_scope'
 require_relative 'stylesheet'
 require_relative 'declarations'
-require_relative 'import_resolver'
+
+# import_resolver is not required here. Stylesheet#load_uri and
+# #resolve_imports require it on entry, so parsing CSS pulls in no networking
+# stdlib and the library loads on hosts without sockets.
 
 # Load pure Ruby implementation modules
 require_relative 'pure/byte_constants'

--- a/lib/cataract/pure.rb
+++ b/lib/cataract/pure.rb
@@ -43,10 +43,6 @@ require_relative 'stylesheet_scope'
 require_relative 'stylesheet'
 require_relative 'declarations'
 
-# import_resolver is not required here. Stylesheet#load_uri and
-# #resolve_imports require it on entry, so parsing CSS pulls in no networking
-# stdlib and the library loads on hosts without sockets.
-
 # Load pure Ruby implementation modules
 require_relative 'pure/byte_constants'
 require_relative 'pure/specificity'

--- a/lib/cataract/stylesheet.rb
+++ b/lib/cataract/stylesheet.rb
@@ -561,6 +561,7 @@ module Cataract
     # @return [self] Returns self for method chaining
     def load_uri(uri, options = {})
       require 'uri'
+      require_relative 'import_resolver'
 
       uri_obj = URI(uri)
       # Reuse the same validation and fetch collaborator @import resolution
@@ -1268,6 +1269,8 @@ module Cataract
     # @param depth [Integer] Current import depth (for depth limit)
     # @return [void]
     def resolve_imports(imports, options, imported_urls: [], depth: 0)
+      require_relative 'import_resolver'
+
       # Normalize options with safe defaults
       opts = ImportResolver.normalize_options(options)
 

--- a/test/wasm/fixtures/imported.css
+++ b/test/wasm/fixtures/imported.css
@@ -1,0 +1,1 @@
+h1 { color: green; }

--- a/test/wasm/smoke.rb
+++ b/test/wasm/smoke.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# Exercises the pure Ruby backend under a real WebAssembly/WASI runtime.
+#
+# Run by .github/workflows/ci-wasm.yml, not by `rake test`. It uses plain
+# raises rather than minitest so it depends on nothing beyond the stdlib the
+# ruby.wasm distribution ships - gem resolution is its own source of failure
+# and isn't what this is measuring.
+#
+# WASI has no sockets, so the C extension can't be built and open-uri,
+# net/http and resolv can't be loaded. What must work is everything that
+# doesn't need them: parsing, serializing, flattening, specificity, and
+# import resolution through a caller-supplied fetcher or the filesystem.
+
+require 'cataract'
+
+@failures = []
+
+def check(name)
+  result = yield
+  raise "returned #{result.inspect}" unless result
+
+  puts "  ok   #{name}"
+rescue StandardError, LoadError => e
+  @failures << "#{name}: #{e.class}: #{e.message}"
+  puts "  FAIL #{name}: #{e.class}: #{e.message}"
+end
+
+puts "ruby #{RUBY_VERSION} #{RUBY_PLATFORM} (#{RUBY_ENGINE})"
+puts "cataract backend: #{Cataract::IMPLEMENTATION}"
+raise 'expected the pure Ruby backend under WASI' unless Cataract::IMPLEMENTATION == :ruby
+
+puts "\nno networking stdlib should be loaded by require alone"
+check('net/http, open-uri, resolv all absent') do
+  $LOADED_FEATURES.grep(%r{/(net/http|open-uri|resolv|ssrf_filter)}).empty?
+end
+
+puts "\nparsing"
+check('basic rule') { Cataract::Stylesheet.parse('body { color: red; }').rules_count == 1 }
+check('media query') { Cataract::Stylesheet.parse('@media print { a { color: #000; } }').rules_count == 1 }
+check('nesting') { Cataract::Stylesheet.parse('.a { color: red; .b { color: blue; } }').rules_count.positive? }
+check('at-rules preserved') { Cataract::Stylesheet.parse('@supports (display: grid) { .g { display: grid; } }').to_s.include?('@supports') }
+
+puts "\nserializing"
+check('to_s round-trips') do
+  Cataract::Stylesheet.parse('body { color: red; }').to_s.include?('color: red')
+end
+check('to_formatted_s') { !Cataract::Stylesheet.parse('body { color: red; }').to_formatted_s.empty? }
+
+puts "\nspecificity"
+check('#id beats .class') do
+  Cataract::Rule.make(id: 0, selector: '#a', declarations: []).specificity >
+    Cataract::Rule.make(id: 1, selector: '.a', declarations: []).specificity
+end
+
+puts "\nflattening"
+check('cascade resolves') do
+  flat = Cataract.flatten(Cataract.parse_css('.a { color: red; } .a { color: blue; }'))
+  flat.rules.first.declarations.any? { |d| d.value == 'blue' }
+end
+check('layered background keeps every layer') do
+  flat = Cataract.flatten(Cataract.parse_css('.a { background: url(x.png), url(y.png) }'))
+  flat.rules.first.declarations.to_h { |d| [d.property, d.value] }['background'] == 'url(x.png), url(y.png)'
+end
+
+puts "\n@import"
+check('parses without resolving') do
+  Cataract::Stylesheet.parse('@import url("other.css"); body { color: red; }').imports.size == 1
+end
+check('resolves via a caller-supplied fetcher') do
+  fetcher = ->(_url, _opts) { 'h1 { color: blue; }' }
+  css = '@import url("https://example.com/other.css"); body { color: red; }'
+  Cataract::Stylesheet.parse(css, import: { fetcher: fetcher }).rules_count == 2
+end
+check('resolves a file:// import from a WASI preopen') do
+  dir = File.expand_path('fixtures', __dir__)
+  css = '@import url("imported.css"); body { color: red; }'
+  sheet = Cataract::Stylesheet.parse(
+    css, import: { base_path: dir, allowed_schemes: %w[file], extensions: %w[css] }
+  )
+  sheet.rules_count == 2
+end
+
+puts
+if @failures.empty?
+  puts 'All WASI checks passed.'
+else
+  puts "#{@failures.size} failure(s):"
+  @failures.each { |f| puts "  - #{f}" }
+  exit 1
+end

--- a/test/wasm/smoke.rb
+++ b/test/wasm/smoke.rb
@@ -7,10 +7,12 @@
 # ruby.wasm distribution ships - gem resolution is its own source of failure
 # and isn't what this is measuring.
 #
-# WASI has no sockets, so the C extension can't be built and open-uri,
-# net/http and resolv can't be loaded. What must work is everything that
-# doesn't need them: parsing, serializing, flattening, specificity, and
-# import resolution through a caller-supplied fetcher or the filesystem.
+# WASI 0.2 defines wasi:sockets, but ruby.wasm's prebuilt binaries target
+# preview1, which has no connect or DNS, and they ship no socket extension
+# either - so net/http and resolv can't load, and the C extension isn't built
+# for wasm at all. What must work is everything that doesn't need them:
+# parsing, serializing, flattening, specificity, and import resolution through
+# a caller-supplied fetcher or the filesystem.
 
 require 'cataract'
 


### PR DESCRIPTION
Adding ssrf_filter in 0.6.0 made `require 'cataract'` depend on the socket extension. Both backends required import_resolver at load time, and that file required open-uri and ssrf_filter at file scope, which pull in net/http and resolv. Parsing a string of CSS needed a networking stack, and the library would not load at all where sockets don't exist - WebAssembly/WASI being the case that matters. v0.5.0 loaded fine there.

Three separate things reached for sockets:

- both backends required import_resolver up front. Stylesheet#load_uri and #resolve_imports now require it on entry instead, which is every path that uses it.
- import_resolver required open-uri and ssrf_filter at file scope, so option validation, URL normalization and file:// fetching couldn't be used without them - and neither could a caller-supplied fetcher, which is how a host with no sockets is meant to resolve imports at all. They load in DefaultFetcher#fetch_http now.
- DefaultFetcher#call named OpenURI::HTTPError, SsrfFilter::Error and SocketError in rescue clauses. Ruby evaluates those constants when an exception passes through, so any failure raised NameError where the libraries were absent - including failures having nothing to do with the network. That translation moved down into #fetch_http with the requires.

#call also rescued StandardError and re-raised as ImportError, which caught the ImportError it had itself raised a few lines earlier, so "Unsupported scheme: ftp" was reported as "Error fetching import: ftp://... (Cataract::ImportError: Unsupported scheme: ftp)". It now re-raises ImportError untouched.

With this, on a host without sockets: the library loads, CSS parses and serializes, flatten works, @import statements parse and survive, and imports resolve either through a caller-supplied fetcher or from the filesystem. Only fetching over HTTP is unavailable, which is inherent.

ci-wasm.yml runs test/wasm/smoke.rb against a real ruby.wasm build under wasmtime to check exactly that. It is workflow_dispatch only: it pulls a prebuilt Ruby, covers the pure backend alone, and answers a question that changes rarely. The script uses plain raises rather than minitest, so gem resolution isn't a second thing that can fail.